### PR TITLE
ci: configure OpenSSF Scorecard security workflow and badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,48 @@
+name: OpenSSF Scorecard
+
+on:
+  schedule:
+    # Run weekly on Mondays at 00:00 UTC
+    - cron: '0 0 * * 1'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard Security Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard
+      security-events: write
+      # Needed to publish results and get a badge
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard Analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 [Documentation](docs/PROJECT_DOCUMENTATION.md) · [Product Spec](docs/PRD.md) · [Task Board](https://github.com/archittmittal/Recover-AI/issues)
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/archittmittal/Recover-AI/badge)](https://scorecard.dev/viewer/?repo=github.com/archittmittal/Recover-AI)
+[![CI Pipeline](https://github.com/archittmittal/Recover-AI/actions/workflows/ci.yml/badge.svg)](https://github.com/archittmittal/Recover-AI/actions/workflows/ci.yml)
+
 </div>
 
 ---


### PR DESCRIPTION
## What
1. Adds \.github/workflows/scorecard.yml\ configuring the official OpenSSF Scorecard GitHub Action (\ossf/scorecard-action@v2.4.0\) with SARIF output and Code Scanning integration (\github/codeql-action/upload-sarif@v3\).
2. Adds OpenSSF Scorecard and CI Pipeline status badges to \README.md\.

## Why
OpenSSF Scorecard automates the evaluation of critical supply-chain security practices, repository risks, branch protections, token permissions, and dependency vulnerabilities to meet industry-grade open source security standards.

## How
- Configured weekly scheduled runs on Monday at 00:00 UTC, on push to \main\, and on \workflow_dispatch\.
- Set least-privilege permissions (\ead-all\ default with scoped \security-events: write\ and \id-token: write\).
- Enabled SARIF export and Code Scanning upload.

## Testing
- Verified GitHub Actions workflow syntax and permissions.
- Verified README badge links.