### PR TITLE
fix: correct OpenSSF Scorecard viewer URI parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [Documentation](docs/PROJECT_DOCUMENTATION.md) · [Product Spec](docs/PRD.md) · [Task Board](https://github.com/archittmittal/Recover-AI/issues)
 
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/archittmittal/Recover-AI/badge)](https://scorecard.dev/viewer/?repo=github.com/archittmittal/Recover-AI)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/archittmittal/Recover-AI/badge)](https://scorecard.dev/viewer/?uri=github.com/archittmittal/Recover-AI)
 [![CI Pipeline](https://github.com/archittmittal/Recover-AI/actions/workflows/ci.yml/badge.svg)](https://github.com/archittmittal/Recover-AI/actions/workflows/ci.yml)
 
 </div>


### PR DESCRIPTION
## What
Updates the OpenSSF Scorecard badge target link in \README.md\ from \https://scorecard.dev/viewer/?repo=...\ to the canonical query format \https://scorecard.dev/viewer/?uri=github.com/archittmittal/Recover-AI\.

## Why
Fixes \invalid repo path\ error on scorecard.dev viewer.

## How
- Scorecard.dev expects the repository query parameter to be named \uri\ rather than \epo\ (e.g., \?uri=github.com/owner/repo\).

## Testing
- Verified link and viewer compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OpenSSF Scorecard badge link to use the current query parameter format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->