### PR TITLE
docs: link OpenSSF Scorecard badge to GitHub Security code scanning report

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [Documentation](docs/PROJECT_DOCUMENTATION.md) · [Product Spec](docs/PRD.md) · [Task Board](https://github.com/archittmittal/Recover-AI/issues)
 
-[![OpenSSF Scorecard](https://img.shields.io/github/actions/workflow/status/archittmittal/Recover-AI/scorecard.yml?label=OpenSSF%20Scorecard&logo=openssf)](https://github.com/archittmittal/Recover-AI/actions/workflows/scorecard.yml)
+[![OpenSSF Scorecard](https://img.shields.io/github/actions/workflow/status/archittmittal/Recover-AI/scorecard.yml?label=OpenSSF%20Scorecard&logo=openssf)](https://github.com/archittmittal/Recover-AI/security/code-scanning?query=tool%3AScorecard)
 [![CI Pipeline](https://img.shields.io/github/actions/workflow/status/archittmittal/Recover-AI/ci.yml?label=CI%20Pipeline&logo=githubactions)](https://github.com/archittmittal/Recover-AI/actions/workflows/ci.yml)
 [![Security & Secret Scanning](https://img.shields.io/github/actions/workflow/status/archittmittal/Recover-AI/security.yml?label=Security%20Scanning&logo=gitguardrails)](https://github.com/archittmittal/Recover-AI/actions/workflows/security.yml)
 


### PR DESCRIPTION
## What
Updates the OpenSSF Scorecard badge target link in \README.md\ to point directly to the repository's GitHub Security Code Scanning analysis view:
\https://github.com/archittmittal/Recover-AI/security/code-scanning?query=tool%3AScorecard\

## Why
Clicking the badge now directly opens the interactive OpenSSF Scorecard findings dashboard.

## Testing
- Verified target URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OpenSSF Scorecard badge link to direct users to the repository’s security code-scanning results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->