### PR TITLE
ci: update changelog workflow to push-to-main trigger with skip-ci

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,9 +1,9 @@
 name: Automated Changelog Updater
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -11,85 +11,100 @@ permissions:
 
 jobs:
   update-changelog:
-    name: Update Changelog on PR Merge
-    if: github.event.pull_request.merged == true && !startsWith(github.event.pull_request.head.ref, 'chore/update-changelog')
+    name: Update Changelog on Main Push
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
-      - name: Update CHANGELOG via GitHub REST API
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Parse Commit & Update CHANGELOG.md
+        id: update_changelog
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const pr = context.payload.pull_request;
-            const prTitle = pr.title.trim();
-            const prNumber = pr.number;
-            const prUrl = pr.html_url;
-            const prAuthor = pr.user.login;
+            const fs = require('fs');
+            const path = 'CHANGELOG.md';
 
-            console.log(`Processing merged PR #${prNumber}: "${prTitle}" by @${prAuthor}`);
-
-            // Map conventional commit type to Keep a Changelog section
-            let section = '### Maintenance & Performance';
-            const lowerTitle = prTitle.toLowerCase();
-
-            if (lowerTitle.startsWith('feat')) {
-              section = '### Added';
-            } else if (lowerTitle.startsWith('fix')) {
-              section = '### Fixed';
-            } else if (lowerTitle.startsWith('docs')) {
-              section = '### Documentation';
-            } else if (lowerTitle.startsWith('ci') || lowerTitle.startsWith('build')) {
-              section = '### CI/CD & Build';
-            } else if (lowerTitle.startsWith('sec') || lowerTitle.includes('security')) {
-              section = '### Security';
-            } else if (lowerTitle.startsWith('refactor') || lowerTitle.startsWith('perf')) {
-              section = '### Maintenance & Performance';
-            }
-
-            const cleanTitle = prTitle.replace(/^[a-z]+(\([^\)]+\))?:\s*/i, '');
-            const entry = `- **${cleanTitle}** in [#${prNumber}](${prUrl}) by @${prAuthor}`;
-
-            // Fetch current CHANGELOG.md from main
-            let fileData;
-            try {
-              fileData = await github.rest.repos.getContent({
-                owner,
-                repo,
-                path: 'CHANGELOG.md',
-                ref: 'main'
-              });
-            } catch (err) {
-              core.setFailed(`Failed to fetch CHANGELOG.md: ${err.message}`);
+            if (!fs.existsSync(path)) {
+              console.log('CHANGELOG.md does not exist yet.');
               return;
             }
 
-            const currentContent = Buffer.from(fileData.data.content, 'base64').toString('utf8');
+            // Get the latest commit on main
+            const headCommit = context.payload.head_commit;
+            if (!headCommit) {
+              console.log('No head commit payload found.');
+              return;
+            }
 
-            if (currentContent.includes(`[#${prNumber}]`)) {
-              console.log(`PR #${prNumber} already recorded in CHANGELOG.md. Skipping.`);
+            const message = headCommit.message || '';
+            console.log(`Analyzing commit message: "${message.split('\n')[0]}"`);
+
+            // Check if commit is a merge commit or direct PR merge
+            const prMatch = message.match(/Merge pull request #(\d+)/i) || message.match(/\(#(\d+)\)/);
+            const prNumber = prMatch ? prMatch[1] : null;
+
+            if (!prNumber) {
+              console.log('Not a PR merge commit. Skipping automated changelog update.');
+              return;
+            }
+
+            const prUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}`;
+            const author = headCommit.author ? headCommit.author.username || headCommit.author.name : 'contributor';
+
+            // Extract the PR subject
+            let subject = message.split('\n')[0];
+            if (subject.startsWith('Merge pull request')) {
+              const lines = message.split('\n').filter(l => l.trim().length > 0);
+              subject = lines.length > 1 ? lines[1].trim() : subject;
+            }
+
+            // Categorize according to Keep a Changelog
+            let section = '### Maintenance & Performance';
+            const lowerSubject = subject.toLowerCase();
+
+            if (lowerSubject.startsWith('feat')) {
+              section = '### Added';
+            } else if (lowerSubject.startsWith('fix')) {
+              section = '### Fixed';
+            } else if (lowerSubject.startsWith('docs')) {
+              section = '### Documentation';
+            } else if (lowerSubject.startsWith('ci') || lowerSubject.startsWith('build')) {
+              section = '### CI/CD & Build';
+            } else if (lowerSubject.startsWith('sec') || lowerSubject.includes('security')) {
+              section = '### Security';
+            } else if (lowerSubject.startsWith('refactor') || lowerSubject.startsWith('perf')) {
+              section = '### Maintenance & Performance';
+            }
+
+            const cleanTitle = subject.replace(/^[a-z]+(\([^\)]+\))?:\s*/i, '').replace(/\s*\(#\d+\)$/, '');
+            const entry = `- **${cleanTitle}** in [#${prNumber}](${prUrl}) by @${author}`;
+
+            let content = fs.readFileSync(path, 'utf8');
+
+            if (content.includes(`[#${prNumber}]`)) {
+              console.log(`PR #${prNumber} is already recorded in CHANGELOG.md. Skipping.`);
               return;
             }
 
             const unreleasedHeader = '## [Unreleased]';
-            const unreleasedIndex = currentContent.indexOf(unreleasedHeader);
+            const unreleasedIndex = content.indexOf(unreleasedHeader);
 
             if (unreleasedIndex === -1) {
-              core.setFailed('Could not locate "## [Unreleased]" header in CHANGELOG.md');
+              console.warn('Could not locate "## [Unreleased]" in CHANGELOG.md');
               return;
             }
 
-            const afterUnreleased = currentContent.slice(unreleasedIndex + unreleasedHeader.length);
+            const afterUnreleased = content.slice(unreleasedIndex + unreleasedHeader.length);
             const nextVersionMatch = afterUnreleased.match(/\n## \[\d+\.\d+\.\d+\]/);
             const unreleasedSectionEnd = nextVersionMatch
               ? unreleasedIndex + unreleasedHeader.length + nextVersionMatch.index
-              : currentContent.length;
+              : content.length;
 
-            let currentUnreleased = currentContent.slice(
+            let currentUnreleased = content.slice(
               unreleasedIndex + unreleasedHeader.length,
               unreleasedSectionEnd
             );
@@ -104,122 +119,20 @@ jobs:
             }
 
             const updatedContent =
-              currentContent.slice(0, unreleasedIndex + unreleasedHeader.length) +
+              content.slice(0, unreleasedIndex + unreleasedHeader.length) +
               currentUnreleased +
-              currentContent.slice(unreleasedSectionEnd);
+              content.slice(unreleasedSectionEnd);
 
-            const branchName = 'chore/update-changelog';
+            fs.writeFileSync(path, updatedContent, 'utf8');
+            console.log(`Updated CHANGELOG.md with entry: ${entry}`);
+            core.setOutput('updated', 'true');
+            core.setOutput('pr_number', prNumber);
 
-            // Get main branch latest commit SHA
-            const mainRef = await github.rest.git.getRef({
-              owner,
-              repo,
-              ref: 'heads/main'
-            });
-            const mainSha = mainRef.data.object.sha;
-
-            // Check or create chore/update-changelog branch
-            let branchExists = false;
-            try {
-              await github.rest.git.getRef({
-                owner,
-                repo,
-                ref: `heads/${branchName}`
-              });
-              branchExists = true;
-            } catch (e) {
-              branchExists = false;
-            }
-
-            if (!branchExists) {
-              try {
-                await github.rest.git.createRef({
-                  owner,
-                  repo,
-                  ref: `refs/heads/${branchName}`,
-                  sha: mainSha
-                });
-                console.log(`Created branch ${branchName} at ${mainSha}`);
-              } catch (createErr) {
-                console.warn(`Could not create branch: ${createErr.message}`);
-              }
-            }
-
-            // Get current file sha on the branch if it exists, or from main
-            let targetSha = fileData.data.sha;
-            if (branchExists) {
-              try {
-                const branchFileData = await github.rest.repos.getContent({
-                  owner,
-                  repo,
-                  path: 'CHANGELOG.md',
-                  ref: branchName
-                });
-                targetSha = branchFileData.data.sha;
-              } catch (e) {
-                targetSha = fileData.data.sha;
-              }
-            }
-
-            // Update CHANGELOG.md on branch
-            try {
-              await github.rest.repos.createOrUpdateFileContents({
-                owner,
-                repo,
-                path: 'CHANGELOG.md',
-                message: `docs(changelog): update CHANGELOG.md for PR #${prNumber}`,
-                content: Buffer.from(updatedContent).toString('base64'),
-                sha: targetSha,
-                branch: branchName
-              });
-              console.log(`Updated CHANGELOG.md on ${branchName}`);
-            } catch (updateErr) {
-              console.warn(`Branch update failed (${updateErr.message}), falling back to direct main commit...`);
-              await github.rest.repos.createOrUpdateFileContents({
-                owner,
-                repo,
-                path: 'CHANGELOG.md',
-                message: `docs(changelog): update CHANGELOG.md for PR #${prNumber} [skip ci]`,
-                content: Buffer.from(updatedContent).toString('base64'),
-                sha: fileData.data.sha,
-                branch: 'main'
-              });
-              console.log(`Updated CHANGELOG.md directly on main.`);
-              return;
-            }
-
-            // Check if open PR already exists for chore/update-changelog
-            const existingPRs = await github.rest.pulls.list({
-              owner,
-              repo,
-              state: 'open',
-              head: `${owner}:${branchName}`,
-              base: 'main'
-            });
-
-            if (existingPRs.data.length > 0) {
-              console.log(`Existing PR #${existingPRs.data[0].number} already open for ${branchName}. Updated.`);
-            } else {
-              try {
-                const newPr = await github.rest.pulls.create({
-                  owner,
-                  repo,
-                  title: `docs(changelog): update CHANGELOG.md for PR #${prNumber}`,
-                  head: branchName,
-                  base: 'main',
-                  body: `Automated changelog update for merged PR [#${prNumber}](${prUrl}).\n- **Title**: \`${prTitle}\`\n- **Author**: @${prAuthor}`
-                });
-                console.log(`Created PR #${newPr.data.number} for changelog update.`);
-              } catch (prErr) {
-                console.warn(`Could not open PR (${prErr.message}). Merging directly to main...`);
-                await github.rest.repos.createOrUpdateFileContents({
-                  owner,
-                  repo,
-                  path: 'CHANGELOG.md',
-                  message: `docs(changelog): update CHANGELOG.md for PR #${prNumber} [skip ci]`,
-                  content: Buffer.from(updatedContent).toString('base64'),
-                  sha: fileData.data.sha,
-                  branch: 'main'
-                });
-              }
-            }
+      - name: Commit and Push to Main
+        if: steps.update_changelog.outputs.updated == 'true'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "docs(changelog): update CHANGELOG.md for PR #${{ steps.update_changelog.outputs.pr_number }} [skip ci]"
+          git push origin main


### PR DESCRIPTION
## What
Updates \.github/workflows/changelog.yml\ to trigger on \push: branches: [main]\:
- Executes in the write-privileged context of \main\.
- Extracts PR merge commit metadata and appends categorized entries to \CHANGELOG.md\ under \## [Unreleased]\.
- Commits and pushes the update directly with \[skip ci]\.

## Why
Avoids GitHub Actions read-only token limitations on fork PR closed events.

## Testing
- Verified parse logic and regex matching.