### PR TITLE
fix: block /api/simulator/* on production deployments by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,10 @@ DATABASE_URL=file:./data/recoverai.db
 
 # Application Configuration
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Set to "true" only on a deployment that is intentionally a public, reset-able
+# demo (e.g. for judging). In a NODE_ENV=production build, /api/simulator/*
+# (seed / pay / reply) is otherwise blocked — those routes are unauthenticated
+# and /api/simulator/seed truncates every table. Leave unset for a real
+# production deployment handling live Razorpay traffic.
+RECOVERAI_DEMO_MODE=false

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Guards the demo/simulator surface (`/api/simulator/*`) from being reachable
+ * on a real production deployment.
+ *
+ * These routes exist to drive the buildathon demo dashboard — seeding data,
+ * simulating a customer payment, injecting a simulated customer reply — and
+ * none of them are authenticated (RA-02, RA-05). `/api/simulator/seed` in
+ * particular truncates every table, including the append-only `audit_logs`.
+ * That is an acceptable, explicitly-invoked reset button for a demo
+ * environment and an unacceptable one for a deployment handling real
+ * Razorpay traffic.
+ *
+ * Blocked whenever NODE_ENV === 'production', unless the deployment opts in
+ * with RECOVERAI_DEMO_MODE=true (e.g. a hosted demo/judging environment that
+ * is intentionally public and reset-able). Anything short of a production
+ * build (local dev, CI, preview deployments) is left untouched so the
+ * existing demo workflow keeps working with zero new required configuration.
+ */
+export function middleware() {
+  const isProduction = process.env.NODE_ENV === 'production';
+  const demoModeOptIn = process.env.RECOVERAI_DEMO_MODE === 'true';
+
+  if (isProduction && !demoModeOptIn) {
+    return NextResponse.json(
+      { success: false, error: { code: 'NOT_FOUND', message: 'Not found' } },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: '/api/simulator/:path*',
+};

--- a/tests/simulator-middleware.test.ts
+++ b/tests/simulator-middleware.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { middleware } from '../src/middleware';
+
+/**
+ * RA-02: /api/simulator/* (seed, pay, reply) has no authentication and
+ * /api/simulator/seed truncates every table, including audit_logs. Blocking
+ * it in a real production deployment (unless explicitly opted into as a demo
+ * environment) is the load-bearing part of the fix.
+ */
+describe('simulator route middleware', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('blocks with 404 in a production build with no opt-in', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('RECOVERAI_DEMO_MODE', '');
+
+    const res = middleware();
+    expect(res.status).toBe(404);
+  });
+
+  it('blocks with 404 in production when the opt-in is set to anything other than "true"', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('RECOVERAI_DEMO_MODE', 'yes');
+
+    const res = middleware();
+    expect(res.status).toBe(404);
+  });
+
+  it('passes through in production when RECOVERAI_DEMO_MODE=true', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('RECOVERAI_DEMO_MODE', 'true');
+
+    const res = middleware();
+    expect(res.status).not.toBe(404);
+  });
+
+  it('passes through outside production regardless of the opt-in', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('RECOVERAI_DEMO_MODE', '');
+
+    const res = middleware();
+    expect(res.status).not.toBe(404);
+  });
+});


### PR DESCRIPTION
## What
Adds `src/middleware.ts`, scoped to `/api/simulator/:path*`, returning 404
whenever `NODE_ENV === 'production'` unless the deployment explicitly opts
in with `RECOVERAI_DEMO_MODE=true`.

## Why
Closes #114

`POST /api/simulator/seed` has no authentication, no env guard, and no
confirmation — it `DELETE`s every table, including the append-only
`audit_logs`. Anyone who can reach the URL can wipe the compliance record
and every customer/journey/audit row with one request. `/pay` and `/reply`
are similarly unauthenticated (tracked separately as RA-09, RA-05).

## How
These routes exist to drive the demo dashboard — Seed Data, Simulate
Payment, simulate a customer reply — so blocking them everywhere would
break the intended demo workflow. The gate only trips in an actual
production build, and only without an explicit opt-in:
- `NODE_ENV !== 'production'` (local dev, CI, preview deployments): **untouched**, zero new configuration required.
- `NODE_ENV === 'production'` and `RECOVERAI_DEMO_MODE` unset/not `"true"`: **404**.
- `NODE_ENV === 'production'` and `RECOVERAI_DEMO_MODE=true`: **passes through** — for a deployment that's intentionally a public, reset-able demo (e.g. judging).

Documented the new variable in `.env.example`.

### Scope note — the DB trigger from the audit's proposed fix
The audit also proposed a DB-level trigger making `audit_logs` literally
un-deletable. I did not include it here: `seedDatabase()`
(`src/lib/db/seed.ts`) deletes `audit_logs` as the *first line* of every
reseed, so a hard trigger would break the same demo-reset flow this issue
depends on preserving. Making both true at once needs `seedDatabase()` to
drop/recreate the trigger around its own delete — a coordinated change I'd
rather do deliberately than bundle in here. Left as a follow-up on #114.

## Testing
`tests/simulator-middleware.test.ts` calls the real `middleware()` export
under all four `(NODE_ENV, RECOVERAI_DEMO_MODE)` combinations that matter.
Also ran a full production build (`npm run build`) locally to confirm
Next.js registers the middleware and scopes it correctly — route map shows
`ƒ Proxy (Middleware)` alongside the `/api/simulator/*` routes.

Verified locally: `npm run typecheck`, `npm run lint`, `npm test` all pass
(53/53). Boundary guardrail re-run manually — clean.

## PR Checklist
- [x] Types: `npx tsc --noEmit` clean
- [x] Lint: no warnings
- [x] Tests: `npm test` passes; new test covers all four env combinations
- [x] Production build verified locally (`npm run build`)
- [x] Issue link: `Closes #114`
- [x] No `src/lib/simulation` import introduced in `recovery`/`ai`
- [x] Scope limited to this issue (DB trigger explicitly deferred, see above)