### PR TITLE
fix: enforce the 8AM-7PM IST contact-hours window in outreach dispatch

### DIFF
--- a/src/lib/recovery/coordinator.ts
+++ b/src/lib/recovery/coordinator.ts
@@ -144,13 +144,15 @@ export class RecoveryCoordinator {
     if (customerList.length === 0) return;
     const customer = customerList[0];
 
-    // Check stopping rules before making an attempt
+    // Check stopping rules before making an attempt. The 8AM-7PM IST contact
+    // window (RBI Fair Practices Code) is enforced here, not skipped — tests
+    // that need to dispatch outreach set a daytime FixedClock instead (RA-06).
     const stoppingCheck = evaluateStoppingRules({
       journeyStatus: journey.status,
       currentAttempt: journey.currentAttempt,
       maxAttempts: journey.maxAttempts,
       customerDndStatus: customer.dndStatus,
-      checkContactHours: false, // In batch simulation/tests we simulate scheduled execution
+      checkContactHours: true,
     });
 
     const now = getClock().now();
@@ -162,18 +164,23 @@ export class RecoveryCoordinator {
           .update(recoveryJourneys)
           .set({ status: stoppingCheck.nextStatus, updatedAt: nowStr })
           .where(eq(recoveryJourneys.id, journeyId));
-
-        await writeAuditLog({
-          journeyId,
-          actor: 'agent',
-          eventType: 'stopping_rule_triggered',
-          eventData: {
-            rule: stoppingCheck.ruleFired,
-            reason: stoppingCheck.reason,
-            newStatus: stoppingCheck.nextStatus,
-          },
-        });
       }
+
+      // Log every fired stopping rule, not only ones that change the status label.
+      // The contact-hours rule's nextStatus ('recovering') is the same string as
+      // the journey's current status while deferred, so gating the log on a
+      // status change silently dropped the audit trail for every deferred
+      // attempt (RA-06) — the one place that record matters most.
+      await writeAuditLog({
+        journeyId,
+        actor: 'agent',
+        eventType: 'stopping_rule_triggered',
+        eventData: {
+          rule: stoppingCheck.ruleFired,
+          reason: stoppingCheck.reason,
+          newStatus: stoppingCheck.nextStatus,
+        },
+      });
       return;
     }
 

--- a/tests/contact-hours-enforcement.test.ts
+++ b/tests/contact-hours-enforcement.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import crypto from 'crypto';
+import fs from 'fs';
+import { eq } from 'drizzle-orm';
+
+/**
+ * RA-06: the 8AM-7PM IST contact window is correctly implemented
+ * (isWithinContactHours, tests/contact-hours.test.ts) but was hardcoded off
+ * at the one call site that actually dispatches outreach
+ * (processRecoveryAttempt passed checkContactHours: false). These tests
+ * exercise the coordinator itself, not just the underlying time helper, so a
+ * regression here can't hide behind a passing unit test on isWithinContactHours.
+ *
+ * Isolated onto its own SQLite file for the same reason as
+ * webhook-idempotency-header.test.ts: it's a second file writing through the
+ * real DB singleton, which would otherwise race e2e-smoke's seedDatabase().
+ */
+const testDbPath = `./data/test-ra06-${crypto.randomUUID()}.db`;
+process.env.DATABASE_URL = `file:${testDbPath}`;
+
+const { db } = await import('../src/lib/db');
+const { customers, paymentFailures, recoveryJourneys, recoveryActions, auditLogs } = await import(
+  '../src/lib/db/schema'
+);
+const { recoveryCoordinator } = await import('../src/lib/recovery/coordinator');
+const { setClock, FixedClock, SystemClock } = await import('../src/lib/utils/time');
+
+async function seedJourney() {
+  const suffix = crypto.randomUUID();
+  const customerId = `cust_ra06_${suffix}`;
+  const failureId = `fail_ra06_${suffix}`;
+  const journeyId = `rj_ra06_${suffix}`;
+  const now = '2026-08-21T14:30:00+05:30';
+
+  await db.insert(customers).values({
+    id: customerId,
+    name: 'Contact Hours Test',
+    email: `ra06-${suffix}@example.com`,
+    phone: '+919876500002',
+    preferredLanguage: 'en',
+    segment: 'b2c',
+    totalFailures: 1,
+    totalRecoveredAmount: 0,
+    dndStatus: 'active',
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  await db.insert(paymentFailures).values({
+    id: failureId,
+    customerId,
+    razorpayPaymentId: `pay_${suffix}`,
+    razorpayOrderId: `order_${suffix}`,
+    amount: 49900,
+    currency: 'INR',
+    paymentMethod: 'card',
+    failureType: 'one_time',
+    errorCode: 'BAD_REQUEST_ERROR',
+    errorSource: 'customer',
+    errorStep: 'authorization',
+    errorReason: 'insufficient_funds',
+    errorDescription: 'Insufficient funds.',
+    createdAt: now,
+  });
+
+  await db.insert(recoveryJourneys).values({
+    id: journeyId,
+    customerId,
+    failureId,
+    status: 'recovering',
+    strategy: 'payment_link',
+    amountAtRisk: 49900,
+    amountRecovered: 0,
+    maxAttempts: 3,
+    currentAttempt: 0,
+    currentChannel: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return journeyId;
+}
+
+describe('processRecoveryAttempt — contact hours enforcement', () => {
+  afterAll(() => {
+    setClock(new SystemClock());
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        fs.unlinkSync(testDbPath + suffix);
+      } catch {
+        // nothing to clean up
+      }
+    }
+  });
+
+  it('dispatches no outreach and defers the journey when invoked at 03:00 IST', async () => {
+    const journeyId = await seedJourney();
+
+    setClock(new FixedClock('2026-08-21T03:00:00+05:30'));
+    await recoveryCoordinator.processRecoveryAttempt(journeyId);
+
+    const actions = await db.select().from(recoveryActions).where(eq(recoveryActions.journeyId, journeyId));
+    expect(actions).toHaveLength(0);
+
+    const [journey] = await db.select().from(recoveryJourneys).where(eq(recoveryJourneys.id, journeyId));
+    expect(journey.currentAttempt).toBe(0);
+    expect(journey.status).toBe('recovering');
+
+    const logs = await db.select().from(auditLogs).where(eq(auditLogs.journeyId, journeyId));
+    const deferred = logs.find((l) => l.eventType === 'stopping_rule_triggered');
+    expect(deferred).toBeDefined();
+    expect(JSON.parse(deferred!.eventData).rule).toBe('outside_contact_hours');
+  });
+
+  it('dispatches outreach when invoked at 14:30 IST', async () => {
+    const journeyId = await seedJourney();
+
+    setClock(new FixedClock('2026-08-21T14:30:00+05:30'));
+    await recoveryCoordinator.processRecoveryAttempt(journeyId);
+
+    const actions = await db.select().from(recoveryActions).where(eq(recoveryActions.journeyId, journeyId));
+    expect(actions).toHaveLength(1);
+
+    const [journey] = await db.select().from(recoveryJourneys).where(eq(recoveryJourneys.id, journeyId));
+    expect(journey.currentAttempt).toBe(1);
+  });
+});


### PR DESCRIPTION
## What
`processRecoveryAttempt` now passes `checkContactHours: true` to
`evaluateStoppingRules` — the RBI Fair Practices Code 8AM-7PM IST contact
window is enforced at the only call site that dispatches real outreach.
Also fixes a related audit-logging gap this surfaced.

## Why
Closes #118

`isWithinContactHours` and the stopping-rules engine's contact-hours check
are both correctly implemented and covered by exact boundary tests
(`tests/contact-hours.test.ts`). None of that mattered: the one place that
calls `evaluateStoppingRules` before dispatching a message hardcoded
`checkContactHours: false`, with the comment *"In batch simulation/tests we
simulate scheduled execution."* A test-mode convenience was the production
default — a failure webhook arriving at 3 AM IST triggered immediate
outreach.

## How
- `checkContactHours: true` in `processRecoveryAttempt`
  (`src/lib/recovery/coordinator.ts`).
- **Related fix surfaced by testing this properly:** the stopping-rule audit
  log was only written when `stoppingCheck.nextStatus !== journey.status`.
  The contact-hours rule's `nextStatus` is `'recovering'` — identical to the
  status an active journey is already in — so every deferred attempt was
  silently missing from the audit trail. Split the DB status update (still
  conditional on an actual change) from the audit log (now written whenever
  any stopping rule fires). Without this, the fix above would enforce
  contact hours correctly but leave zero record of why an attempt didn't go
  out.

## Testing
`tests/contact-hours-enforcement.test.ts` exercises the coordinator itself,
not just the underlying time helper — a passing `isWithinContactHours` unit
test couldn't have caught this regression, since the bug was in whether the
coordinator called it at all:
1. `processRecoveryAttempt` at 03:00 IST → zero rows in `recovery_actions`,
   `currentAttempt` unchanged, journey stays `'recovering'`, and an
   `outside_contact_hours` audit entry exists.
2. Same journey at 14:30 IST → one action dispatched, `currentAttempt`
   advances to 1.

All pre-existing tests pass unmodified — `e2e-smoke.test.ts` already used a
daytime `FixedClock` (14:30 IST), so nothing was relying on the old
behavior.

Verified locally: `npm run typecheck`, `npm run lint`, `npm test` all pass
(51/51, stable across repeated runs). Boundary guardrail re-run manually —
clean.

## PR Checklist
- [x] Types: `npx tsc --noEmit` clean
- [x] Lint: no warnings
- [x] Contact hours: outreach now respects the 8AM–7PM IST window
- [x] Audit: the deferral itself now writes to `audit_logs`
- [x] Tests: `npm test` passes; new test exercises the coordinator directly
- [x] Issue link: `Closes #118`
- [x] No `src/lib/simulation` import introduced in `recovery`/`ai`
- [x] Scope limited to this issue (plus the directly-related audit-log gap it exposed)