### PR TITLE
fix: enforce strategy-configured retry backoff between attempts

### DIFF
--- a/src/lib/recovery/coordinator.ts
+++ b/src/lib/recovery/coordinator.ts
@@ -5,7 +5,7 @@ import {
   recoveryJourneys,
   recoveryActions,
 } from '../db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, desc } from 'drizzle-orm';
 import { generateId } from '../utils/ids';
 import { getClock, formatIST } from '../utils/time';
 import { writeAuditLog } from '../utils/audit';
@@ -135,6 +135,24 @@ export class RecoveryCoordinator {
       return;
     }
 
+    // Respect the strategy's configured retry backoff (retryIntervalsHours). Each
+    // action's scheduledAt records the earliest time the *next* attempt may fire
+    // (see where it's computed below); if that time hasn't arrived, this call is
+    // a no-op instead of dispatching immediately (RA-07). Without this, a caller
+    // that invokes processRecoveryAttempt repeatedly — e.g. a sweep triggered
+    // every minute — burns a journey's entire attempt ladder in seconds instead
+    // of across the days retryIntervalsHours specifies.
+    const [latestAction] = await db
+      .select()
+      .from(recoveryActions)
+      .where(eq(recoveryActions.journeyId, journeyId))
+      .orderBy(desc(recoveryActions.attemptNumber))
+      .limit(1);
+
+    if (latestAction && new Date(latestAction.scheduledAt) > getClock().now()) {
+      return;
+    }
+
     const customerList = await db
       .select()
       .from(customers)
@@ -221,7 +239,11 @@ export class RecoveryCoordinator {
     });
 
     const actionId = generateId('ra');
-    const scheduleInfo = calculateNextScheduledTime(0);
+    // scheduledAt on this row marks when the *next* attempt (nextAttempt + 1) is
+    // allowed to fire, per the strategy's configured backoff — not when this
+    // attempt itself ran (that's executedAt, set to nowStr below).
+    const nextIntervalHours = strategyConfig.retryIntervalsHours[nextAttempt - 1] ?? 24;
+    const scheduleInfo = calculateNextScheduledTime(nextIntervalHours);
 
     // Record recovery action
     await db.insert(recoveryActions).values({

--- a/tests/e2e-smoke.test.ts
+++ b/tests/e2e-smoke.test.ts
@@ -43,6 +43,11 @@ describe('RecoverAI End-to-End Autonomous Workflow Smoke Suite', () => {
     expect(journeys[0].currentAttempt).toBe(1);
     expect(journeys[0].status).toBe('recovering');
 
+    // Attempt 2 is gated behind the strategy's configured retry backoff
+    // (retryIntervalsHours) — advance the clock well past the longest
+    // interval any strategy declares (72h) before the next attempt is due.
+    setClock(new FixedClock(new Date(Date.parse('2026-08-21T14:30:00+05:30') + 73 * 60 * 60 * 1000)));
+
     // Executing next attempt advances to Attempt 2 (SMS Escalation)
     await recoveryCoordinator.processRecoveryAttempt(journeyId);
 
@@ -62,6 +67,10 @@ describe('RecoverAI End-to-End Autonomous Workflow Smoke Suite', () => {
     expect(actions.length).toBe(2);
     expect(actions[0].attemptNumber).toBe(1);
     expect(actions[1].attemptNumber).toBe(2);
+
+    // Restore the shared clock so later tests in this file see the original
+    // daytime timestamp rather than the 73h jump made above.
+    setClock(new FixedClock('2026-08-21T14:30:00+05:30'));
   });
 
   it('3. Resolves journey when customer completes payment via link', async () => {

--- a/tests/retry-backoff-enforcement.test.ts
+++ b/tests/retry-backoff-enforcement.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import crypto from 'crypto';
+import fs from 'fs';
+import { eq } from 'drizzle-orm';
+
+/**
+ * RA-07: retryIntervalsHours is specified per strategy but the scheduler was
+ * always called with offset 0, and nothing gated a repeated call on whether
+ * the next attempt was actually due — so a caller invoking
+ * processRecoveryAttempt in a tight loop (e.g. a sweep run every minute)
+ * could exhaust a journey's entire attempt ladder in seconds instead of
+ * across the days the strategy configures.
+ *
+ * Isolated onto its own SQLite file for the same reason as the RA-04/RA-06
+ * tests: it's a third file writing through the real DB singleton, which
+ * would otherwise race e2e-smoke's seedDatabase() truncation.
+ */
+const testDbPath = `./data/test-ra07-${crypto.randomUUID()}.db`;
+process.env.DATABASE_URL = `file:${testDbPath}`;
+
+const { db } = await import('../src/lib/db');
+const { customers, paymentFailures, recoveryJourneys, recoveryActions } = await import('../src/lib/db/schema');
+const { recoveryCoordinator } = await import('../src/lib/recovery/coordinator');
+const { setClock, FixedClock, SystemClock } = await import('../src/lib/utils/time');
+const { STRATEGY_CONFIGS } = await import('../src/lib/recovery/strategies');
+
+const DAYTIME_START = '2026-08-21T08:30:00+05:30';
+
+async function seedJourney(strategy: string) {
+  const suffix = crypto.randomUUID();
+  const customerId = `cust_ra07_${suffix}`;
+  const failureId = `fail_ra07_${suffix}`;
+  const journeyId = `rj_ra07_${suffix}`;
+  const now = DAYTIME_START;
+
+  await db.insert(customers).values({
+    id: customerId,
+    name: 'Retry Backoff Test',
+    email: `ra07-${suffix}@example.com`,
+    phone: '+919876500003',
+    preferredLanguage: 'en',
+    segment: 'b2c',
+    totalFailures: 1,
+    totalRecoveredAmount: 0,
+    dndStatus: 'active',
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  await db.insert(paymentFailures).values({
+    id: failureId,
+    customerId,
+    razorpayPaymentId: `pay_${suffix}`,
+    razorpayOrderId: `order_${suffix}`,
+    amount: 49900,
+    currency: 'INR',
+    paymentMethod: 'card',
+    failureType: 'one_time',
+    errorCode: 'BAD_REQUEST_ERROR',
+    errorSource: 'customer',
+    errorStep: 'authorization',
+    errorReason: 'insufficient_funds',
+    errorDescription: 'Insufficient funds.',
+    createdAt: now,
+  });
+
+  await db.insert(recoveryJourneys).values({
+    id: journeyId,
+    customerId,
+    failureId,
+    status: 'recovering',
+    strategy,
+    amountAtRisk: 49900,
+    amountRecovered: 0,
+    maxAttempts: STRATEGY_CONFIGS[strategy as keyof typeof STRATEGY_CONFIGS].maxAttempts,
+    currentAttempt: 0,
+    currentChannel: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return journeyId;
+}
+
+describe('processRecoveryAttempt — retry backoff enforcement', () => {
+  afterAll(() => {
+    setClock(new SystemClock());
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        fs.unlinkSync(testDbPath + suffix);
+      } catch {
+        // nothing to clean up
+      }
+    }
+  });
+
+  it('does not dispatch a second attempt immediately after the first (payment_link: 1h backoff)', async () => {
+    const journeyId = await seedJourney('payment_link');
+    setClock(new FixedClock(DAYTIME_START));
+
+    await recoveryCoordinator.processRecoveryAttempt(journeyId);
+    // Three consecutive calls with no clock advance — matches a sweep fired repeatedly.
+    await recoveryCoordinator.processRecoveryAttempt(journeyId);
+    await recoveryCoordinator.processRecoveryAttempt(journeyId);
+
+    const actions = await db.select().from(recoveryActions).where(eq(recoveryActions.journeyId, journeyId));
+    expect(actions).toHaveLength(1);
+    expect(actions[0].attemptNumber).toBe(1);
+
+    const [journey] = await db.select().from(recoveryJourneys).where(eq(recoveryJourneys.id, journeyId));
+    expect(journey.currentAttempt).toBe(1);
+  });
+
+  it('dispatches the second attempt once the configured backoff has elapsed', async () => {
+    const journeyId = await seedJourney('payment_link');
+    setClock(new FixedClock(DAYTIME_START));
+
+    await recoveryCoordinator.processRecoveryAttempt(journeyId); // attempt 1
+
+    // payment_link's retryIntervalsHours[0] === 1 (hour). Advance just past it.
+    setClock(new FixedClock(new Date(Date.parse(DAYTIME_START) + 61 * 60 * 1000)));
+    await recoveryCoordinator.processRecoveryAttempt(journeyId); // attempt 2
+
+    const actions = await db.select().from(recoveryActions).where(eq(recoveryActions.journeyId, journeyId));
+    expect(actions).toHaveLength(2);
+
+    const [journey] = await db.select().from(recoveryJourneys).where(eq(recoveryJourneys.id, journeyId));
+    expect(journey.currentAttempt).toBe(2);
+  });
+
+  it('does not throw for merchant_alert, whose retryIntervalsHours is empty', async () => {
+    const journeyId = await seedJourney('merchant_alert');
+    setClock(new FixedClock(DAYTIME_START));
+
+    await expect(recoveryCoordinator.processRecoveryAttempt(journeyId)).resolves.not.toThrow();
+
+    const [journey] = await db.select().from(recoveryJourneys).where(eq(recoveryJourneys.id, journeyId));
+    // merchant_alert has maxAttempts: 1, so a single attempt exhausts it.
+    expect(journey.status).toBe('exhausted');
+  });
+});


### PR DESCRIPTION
## What
`processRecoveryAttempt` now respects each strategy's `retryIntervalsHours`
instead of being able to fire every attempt back-to-back. A journey's next
attempt won't dispatch until the configured backoff has actually elapsed.

## Why
Closes #119

Every `StrategyConfig` in `src/lib/recovery/strategies.ts` declares
`retryIntervalsHours` (e.g. `payment_link: [1, 24, 72]`), but the only call
site building a schedule used `calculateNextScheduledTime(0)` — always
"now" — and nothing ever checked whether a prior attempt's schedule had
actually elapsed before making the next one. A caller invoking
`processRecoveryAttempt` repeatedly (a sweep fired every minute, or just a
few quick manual retries) could exhaust a journey's entire 3-attempt ladder
in seconds, identically whether the last attempt was one second or one day
ago.

## How
- `recovery_actions.scheduledAt` on attempt *N* now records when attempt
  *N+1* is allowed to fire: `calculateNextScheduledTime` is called with
  `strategyConfig.retryIntervalsHours[nextAttempt - 1]` (falling back to
  24h for a strategy with fewer configured intervals than attempts, e.g.
  `merchant_alert`'s empty array) instead of a hardcoded `0`.
- `processRecoveryAttempt` now looks up the journey's most recent action
  and returns without dispatching if that action's `scheduledAt` is still
  in the future. This is the actual enforcement — the first change alone
  only annotated a timestamp without changing when dispatch happened.

`tests/e2e-smoke.test.ts`'s escalation test previously called
`processRecoveryAttempt` twice with no clock advance and asserted **both**
dispatched immediately — that assertion encoded exactly the bug this PR
fixes. Updated it to advance the clock past the backoff window before the
second call, and restore it afterward so later tests in the file see the
original timestamp.

## Testing
`tests/retry-backoff-enforcement.test.ts` exercises the coordinator
directly:
1. Three consecutive `processRecoveryAttempt` calls with no clock advance
   → exactly one action row, `currentAttempt` stays at 1.
2. Same journey, clock advanced past `payment_link`'s 1h interval → second
   attempt dispatches, `currentAttempt` becomes 2.
3. `merchant_alert` (empty `retryIntervalsHours`) → resolves without
   throwing; its single attempt exhausts the journey as expected
   (`maxAttempts: 1`).

Verified locally: `npm run typecheck`, `npm run lint`, `npm test` all pass
(52/52, stable across repeated runs). Boundary guardrail re-run manually —
clean.

## PR Checklist
- [x] Types: `npx tsc --noEmit` clean
- [x] Lint: no warnings
- [x] Tests: `npm test` passes; new test proves the gate, updated test no
      longer encodes the bug it used to rely on
- [x] Issue link: `Closes #119`
- [x] No `src/lib/simulation` import introduced in `recovery`/`ai`
- [x] Scope limited to this issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery attempts now respect configured retry intervals before dispatching another attempt.
  * Repeated immediate requests no longer trigger duplicate recovery attempts.
  * Recovery strategies with no retry interval now complete gracefully and become exhausted.

* **Tests**
  * Added coverage for retry timing, delayed attempts, and exhausted recovery workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->