### PR TITLE
fix: unify opt-out detection into a single shared matcher

### DIFF
--- a/src/lib/ai/conversation.ts
+++ b/src/lib/ai/conversation.ts
@@ -1,5 +1,6 @@
 import { gemini } from './gemini';
 import { CONVERSATIONAL_REPLY_SYSTEM_PROMPT } from './prompts';
+import { detectOptOut } from '../recovery/stopping-rules';
 
 export interface ConversationInput {
   customerName: string;
@@ -21,18 +22,10 @@ export interface ConversationResponse {
 export async function processCustomerConversation(
   input: ConversationInput
 ): Promise<ConversationResponse> {
-  const text = input.customerMessage.trim().toLowerCase();
-
-  // 1. Fast deterministic check for hard opt-outs across English and Hindi/Hinglish
-  if (
-    text === 'stop' ||
-    text.includes('stop') ||
-    text.includes('unsubscribe') ||
-    text.includes('band karo') ||
-    text.includes('mat bhejo') ||
-    text.includes('mat karo') ||
-    text.includes('cancel')
-  ) {
+  // 1. Fast deterministic check for hard opt-outs across English and Hindi/Hinglish.
+  // Uses the same matcher as the deterministic stopping-rule engine so the two
+  // can never drift out of sync (see RA-08/RA-11).
+  if (detectOptOut(input.customerMessage)) {
     return {
       responseMessage: `You have been unsubscribed. No further messages will be sent. Thank you.`,
       intent: 'opt_out',

--- a/src/lib/recovery/stopping-rules.ts
+++ b/src/lib/recovery/stopping-rules.ts
@@ -1,5 +1,58 @@
 import { isWithinContactHours, getClock } from '../utils/time';
 
+// Multi-word Hindi/Hinglish/Devanagari opt-out phrases. Matched via plain
+// substring since these are distinctive phrases, not single ambiguous words.
+const OPT_OUT_PHRASES = [
+  'band karo',
+  'mat bhejo',
+  'mat karo',
+  'बंद करो',
+  'रोको',
+  'मत भेजो',
+];
+
+// Single/short English opt-out keywords. Matched with word boundaries so
+// "the bank stopped my transaction" does NOT match "stop", while
+// "please stop sending" does.
+const OPT_OUT_KEYWORDS = [
+  'stop',
+  'unsubscribe',
+  'opt out',
+  'optout',
+  'do not contact',
+  "don't contact",
+  'remove me',
+  'do not text',
+  'do not message',
+  'do not sms',
+  'stop messaging',
+  'stop texting',
+  'no more messages',
+];
+
+/**
+ * Single source of truth for detecting a customer opt-out request.
+ * Shared by the deterministic stopping-rule engine and the conversational
+ * agent so the two can never drift out of sync (see RA-08/RA-11).
+ */
+export function detectOptOut(message: string | null | undefined): boolean {
+  if (!message) return false;
+  const text = message.trim().toLowerCase();
+  if (!text) return false;
+
+  for (const phrase of OPT_OUT_PHRASES) {
+    if (text.includes(phrase.toLowerCase())) return true;
+  }
+
+  for (const keyword of OPT_OUT_KEYWORDS) {
+    const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`(^|\\W)${escaped}(\\W|$)`, 'i');
+    if (pattern.test(text)) return true;
+  }
+
+  return false;
+}
+
 export interface StoppingRuleEvaluationContext {
   journeyStatus: string;
   currentAttempt: number;
@@ -31,23 +84,14 @@ export function evaluateStoppingRules(ctx: StoppingRuleEvaluationContext): Stopp
     };
   }
 
-  // 2. Customer Opt-Out via "STOP" / "unsubscribe"
-  if (ctx.customerMessage) {
-    const text = ctx.customerMessage.trim().toLowerCase();
-    if (
-      text === 'stop' ||
-      text.includes('stop') ||
-      text.includes('unsubscribe') ||
-      text.includes('band karo') ||
-      text.includes('mat bhejo')
-    ) {
-      return {
-        shouldStop: true,
-        ruleFired: 'opt_out',
-        nextStatus: 'opted_out',
-        reason: 'Customer explicitly requested opt-out ("STOP"). Immediately halting outreach and enabling DND.',
-      };
-    }
+  // 2. Customer Opt-Out via "STOP" / "unsubscribe" / equivalents
+  if (detectOptOut(ctx.customerMessage)) {
+    return {
+      shouldStop: true,
+      ruleFired: 'opt_out',
+      nextStatus: 'opted_out',
+      reason: 'Customer explicitly requested opt-out ("STOP"). Immediately halting outreach and enabling DND.',
+    };
   }
 
   // 3. Customer already in DND status

--- a/tests/optout-matcher.test.ts
+++ b/tests/optout-matcher.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { detectOptOut, evaluateStoppingRules } from '../src/lib/recovery/stopping-rules';
+
+describe('detectOptOut — shared opt-out matcher (RA-08 / RA-11)', () => {
+  describe('true positives (should detect opt-out)', () => {
+    const shouldMatch = [
+      'STOP',
+      'stop',
+      'Stop please',
+      'Please stop sending',
+      'UNSUBSCRIBE',
+      'unsubscribe',
+      'Please unsubscribe me',
+      'band karo',
+      'ab band karo msg bhejna',
+      'mat bhejo',
+      'mat bhejo message',
+      'mat karo',
+      'do not contact me again',
+      "don't contact me",
+      'remove me from your list',
+      'opt out',
+      'optout please',
+      'please do not text me',
+      'do not message me anymore',
+      'stop texting me',
+      'no more messages please',
+      'बंद करो',
+      'रोको',
+      'मत भेजो',
+    ];
+
+    it.each(shouldMatch)('detects opt-out in "%s"', (msg) => {
+      expect(detectOptOut(msg)).toBe(true);
+    });
+  });
+
+  describe('true negatives (should NOT falsely trigger opt-out)', () => {
+    const shouldNotMatch = [
+      'the bank stopped my transaction',
+      'my card stopped working',
+      'can you help me complete the payment',
+      'I will pay tomorrow',
+      'what is the amount due',
+      '',
+      null,
+      undefined,
+    ];
+
+    it.each(shouldNotMatch)('does not flag "%s" as opt-out', (msg) => {
+      expect(detectOptOut(msg as string | null | undefined)).toBe(false);
+    });
+  });
+});
+
+describe('evaluateStoppingRules — opt-out rule uses shared matcher', () => {
+  it('fires opt_out on a previously-missed false negative ("do not contact me again")', () => {
+    const res = evaluateStoppingRules({
+      journeyStatus: 'recovering',
+      currentAttempt: 1,
+      maxAttempts: 3,
+      customerDndStatus: 'active',
+      customerMessage: 'do not contact me again',
+    });
+
+    expect(res.shouldStop).toBe(true);
+    expect(res.ruleFired).toBe('opt_out');
+    expect(res.nextStatus).toBe('opted_out');
+  });
+
+  it('does NOT fire opt_out on a previously-known false positive ("the bank stopped my transaction")', () => {
+    const res = evaluateStoppingRules({
+      journeyStatus: 'recovering',
+      currentAttempt: 1,
+      maxAttempts: 3,
+      customerDndStatus: 'active',
+      customerMessage: 'the bank stopped my transaction, please help',
+    });
+
+    expect(res.shouldStop).toBe(false);
+    expect(res.ruleFired).toBeNull();
+  });
+
+  it('fires opt_out on Devanagari phrase "बंद करो"', () => {
+    const res = evaluateStoppingRules({
+      journeyStatus: 'recovering',
+      currentAttempt: 1,
+      maxAttempts: 3,
+      customerDndStatus: 'active',
+      customerMessage: 'कृपया बंद करो',
+    });
+
+    expect(res.shouldStop).toBe(true);
+    expect(res.ruleFired).toBe('opt_out');
+  });
+});


### PR DESCRIPTION
## Summary
- `stopping-rules.ts` and `conversation.ts` each kept their own inline opt-out keyword list; the lists had already drifted (`conversation.ts` matched `cancel`/`mat karo`, `stopping-rules.ts` didn't), so the agent could tell a customer they were unsubscribed while the DB never set `dndStatus: 'opted_out'`.
- Both lists used raw substring matching on `"stop"`, so `"the bank stopped my transaction"` false-positived, while genuine opt-outs like `"do not contact me again"`, `"remove me from your list"`, `"opt out"`, and Devanagari phrasings (`बंद करो`, `रोको`, `मत भेजो`) were false negatives.
- Exported a single `detectOptOut()` from `stopping-rules.ts` — word-boundary matching over an explicit English keyword set, substring matching over an explicit Hindi/Hinglish/Devanagari phrase set. `conversation.ts` now imports and calls it instead of keeping its own list, so the two paths cannot drift again.
- Dropped `cancel` from the deterministic set (too ambiguous — e.g. "can I cancel and pay later"); the LLM conversational path still handles that nuance via intent classification.

## Test plan
- [x] New `tests/optout-matcher.test.ts`: true-positive corpus (STOP/unsubscribe variants, previously-missed phrases, Devanagari), true-negative corpus (false positives like "stopped"/"stopped working"), plus `evaluateStoppingRules` integration checks.
- [x] Existing `tests/stopping-rules.test.ts` and `tests/ethical-compliance.test.ts` opt-out phrase suites still pass unchanged against the new matcher.
- [x] `npm run typecheck` clean, `npm run lint` clean.
- [x] `npm test` — 84/84 passing, run 3x consecutively with no flakes.
- [x] Boundary-guardrail grep (`src/lib/recovery/`, `src/lib/ai/` vs `simulation`) — no violations.
- [x] `npm run build` — production build succeeds.

Closes #120
Closes #123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved opt-out detection across conversations and stopping rules.
  * Recognizes additional English, Hindi, Hinglish, and Devanagari opt-out phrases.
  * Reduces false positives by matching English keywords as complete phrases.
  * Handles empty or missing messages safely.
* **Tests**
  * Added coverage for supported opt-out phrases, safeguards, and integration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->