### PR TITLE
fix: make journey resolution idempotent and attribute conversions to channel actions

### DIFF
--- a/src/lib/recovery/coordinator.ts
+++ b/src/lib/recovery/coordinator.ts
@@ -5,7 +5,7 @@ import {
   recoveryJourneys,
   recoveryActions,
 } from '../db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, desc } from 'drizzle-orm';
 import { generateId } from '../utils/ids';
 import { getClock, formatIST } from '../utils/time';
 import { writeAuditLog } from '../utils/audit';
@@ -355,6 +355,11 @@ export class RecoveryCoordinator {
     if (journeyList.length === 0) return;
     const journey = journeyList[0];
 
+    // Idempotency guard: this journey's payment has already been recorded.
+    // Without this, repeated calls (retried webhooks, replayed simulator
+    // requests) would keep incrementing the customer's lifetime total.
+    if (journey.status === 'resolved') return;
+
     await db
       .update(recoveryJourneys)
       .set({
@@ -366,23 +371,42 @@ export class RecoveryCoordinator {
       })
       .where(eq(recoveryJourneys.id, journeyId));
 
-    // Update customer total recovered statistics
-    const customerList = await db
+    // Attribute the conversion to the most recent outreach action so channel
+    // metrics can report real conversion rates instead of always reading 0.
+    const [lastAction] = await db
       .select()
-      .from(customers)
-      .where(eq(customers.id, journey.customerId))
+      .from(recoveryActions)
+      .where(eq(recoveryActions.journeyId, journeyId))
+      .orderBy(desc(recoveryActions.attemptNumber))
       .limit(1);
 
-    if (customerList.length > 0) {
-      const customer = customerList[0];
+    if (lastAction) {
       await db
-        .update(customers)
-        .set({
-          totalRecoveredAmount: (customer.totalRecoveredAmount || 0) + amountPaid,
-          updatedAt: nowStr,
-        })
-        .where(eq(customers.id, customer.id));
+        .update(recoveryActions)
+        .set({ outcome: 'payment_completed' })
+        .where(eq(recoveryActions.id, lastAction.id));
     }
+
+    // Recompute the customer's lifetime recovered total as a derived sum over
+    // their journeys, rather than maintaining an incrementing counter that
+    // can drift out of sync with the source of truth.
+    const customerJourneys = await db
+      .select({ amountRecovered: recoveryJourneys.amountRecovered })
+      .from(recoveryJourneys)
+      .where(eq(recoveryJourneys.customerId, journey.customerId));
+
+    const totalRecoveredAmount = customerJourneys.reduce(
+      (sum, j) => sum + j.amountRecovered,
+      0
+    );
+
+    await db
+      .update(customers)
+      .set({
+        totalRecoveredAmount,
+        updatedAt: nowStr,
+      })
+      .where(eq(customers.id, journey.customerId));
 
     await writeAuditLog({
       journeyId,

--- a/tests/resolution-idempotency.test.ts
+++ b/tests/resolution-idempotency.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import crypto from 'crypto';
+import fs from 'fs';
+
+// Isolate this suite onto its own on-disk DB file so it never races the
+// shared DB used by tests/e2e-smoke.test.ts (which truncates all tables in
+// its own beforeAll under Vitest's parallel-by-default file execution).
+const dbFile = `./data/test-ra09-${crypto.randomUUID()}.db`;
+process.env.DATABASE_URL = `file:${dbFile}`;
+
+let db: typeof import('../src/lib/db')['db'];
+let schema: typeof import('../src/lib/db/schema');
+let recoveryCoordinator: typeof import('../src/lib/recovery/coordinator')['recoveryCoordinator'];
+let generateId: typeof import('../src/lib/utils/ids')['generateId'];
+let getClock: typeof import('../src/lib/utils/time')['getClock'];
+let setClock: typeof import('../src/lib/utils/time')['setClock'];
+let FixedClock: typeof import('../src/lib/utils/time')['FixedClock'];
+let formatIST: typeof import('../src/lib/utils/time')['formatIST'];
+let eq: typeof import('drizzle-orm')['eq'];
+
+async function seedJourney(amountAtRisk: number) {
+  const nowStr = formatIST(getClock().now());
+  const customerId = generateId('cust');
+  const failureId = generateId('fail');
+  const journeyId = generateId('rj');
+  const actionId = generateId('ra');
+
+  await db.insert(schema.customers).values({
+    id: customerId,
+    name: 'Priya Desai',
+    email: 'priya@example.com',
+    phone: '+919800000000',
+    preferredLanguage: 'en',
+    segment: 'b2c',
+    totalFailures: 1,
+    totalRecoveredAmount: 0,
+    dndStatus: 'active',
+    createdAt: nowStr,
+    updatedAt: nowStr,
+  });
+
+  await db.insert(schema.paymentFailures).values({
+    id: failureId,
+    customerId,
+    razorpayPaymentId: 'pay_fail_1',
+    razorpayOrderId: 'order_1',
+    amount: amountAtRisk,
+    currency: 'INR',
+    paymentMethod: 'card',
+    failureType: 'one_time',
+    errorCode: 'BAD_REQUEST_ERROR',
+    errorSource: 'customer',
+    errorStep: 'authorization',
+    errorReason: 'insufficient_funds',
+    errorDescription: 'Insufficient funds',
+    createdAt: nowStr,
+  });
+
+  await db.insert(schema.recoveryJourneys).values({
+    id: journeyId,
+    customerId,
+    failureId,
+    status: 'recovering',
+    strategy: 'payment_link',
+    amountAtRisk,
+    amountRecovered: 0,
+    maxAttempts: 3,
+    currentAttempt: 1,
+    currentChannel: 'whatsapp',
+    createdAt: nowStr,
+    updatedAt: nowStr,
+  });
+
+  await db.insert(schema.recoveryActions).values({
+    id: actionId,
+    journeyId,
+    attemptNumber: 1,
+    channel: 'whatsapp',
+    actionType: 'payment_link',
+    messageContent: 'Please complete your payment.',
+    deliveryStatus: 'sent',
+    customerResponse: null,
+    outcome: 'pending',
+    scheduledAt: nowStr,
+    executedAt: nowStr,
+    createdAt: nowStr,
+  });
+
+  return { customerId, journeyId, actionId };
+}
+
+describe('resolveJourneyWithPayment — resolution idempotency & channel attribution (RA-09 / RA-13)', () => {
+  beforeAll(async () => {
+    ({ db } = await import('../src/lib/db'));
+    schema = await import('../src/lib/db/schema');
+    ({ recoveryCoordinator } = await import('../src/lib/recovery/coordinator'));
+    ({ generateId } = await import('../src/lib/utils/ids'));
+    ({ getClock, setClock, FixedClock, formatIST } = await import('../src/lib/utils/time'));
+    ({ eq } = await import('drizzle-orm'));
+    setClock(new FixedClock('2026-08-21T14:30:00+05:30'));
+  });
+
+  afterAll(() => {
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        fs.unlinkSync(`${dbFile}${suffix}`);
+      } catch {
+        // file may not exist
+      }
+    }
+  });
+
+  it('does not double-count the customer lifetime total when called twice', async () => {
+    const { customerId, journeyId } = await seedJourney(500000);
+
+    await recoveryCoordinator.resolveJourneyWithPayment(journeyId, 'pay_resolved_1', 500000);
+    await recoveryCoordinator.resolveJourneyWithPayment(journeyId, 'pay_resolved_1', 500000);
+
+    const [customer] = await db.select().from(schema.customers).where(eq(schema.customers.id, customerId));
+    expect(customer.totalRecoveredAmount).toBe(500000);
+
+    const [journey] = await db.select().from(schema.recoveryJourneys).where(eq(schema.recoveryJourneys.id, journeyId));
+    expect(journey.amountRecovered).toBe(500000);
+  });
+
+  it('writes exactly one payment_recovered audit entry across two calls', async () => {
+    const { journeyId } = await seedJourney(300000);
+
+    await recoveryCoordinator.resolveJourneyWithPayment(journeyId, 'pay_resolved_2', 300000);
+    await recoveryCoordinator.resolveJourneyWithPayment(journeyId, 'pay_resolved_2', 300000);
+
+    const logs = await db
+      .select()
+      .from(schema.auditLogs)
+      .where(eq(schema.auditLogs.journeyId, journeyId));
+    const recoveredLogs = logs.filter((l) => l.eventType === 'payment_recovered');
+    expect(recoveredLogs.length).toBe(1);
+  });
+
+  it('sets outcome payment_completed on the most recent action, lighting up channel attribution', async () => {
+    const { journeyId, actionId } = await seedJourney(200000);
+
+    await recoveryCoordinator.resolveJourneyWithPayment(journeyId, 'pay_resolved_3', 200000);
+
+    const [action] = await db.select().from(schema.recoveryActions).where(eq(schema.recoveryActions.id, actionId));
+    expect(action.outcome).toBe('payment_completed');
+  });
+
+  it('keeps totalRecoveredAmount equal to the sum of that customer journeys amountRecovered', async () => {
+    const nowStr = formatIST(getClock().now());
+    const customerId = generateId('cust');
+
+    await db.insert(schema.customers).values({
+      id: customerId,
+      name: 'Rohan Iyer',
+      email: 'rohan@example.com',
+      phone: '+919811111111',
+      preferredLanguage: 'en',
+      segment: 'b2c',
+      totalFailures: 2,
+      totalRecoveredAmount: 0,
+      dndStatus: 'active',
+      createdAt: nowStr,
+      updatedAt: nowStr,
+    });
+
+    async function seedJourneyForCustomer(amount: number) {
+      const failureId = generateId('fail');
+      const journeyId = generateId('rj');
+      await db.insert(schema.paymentFailures).values({
+        id: failureId,
+        customerId,
+        razorpayPaymentId: 'pay_fail_x',
+        razorpayOrderId: 'order_x',
+        amount,
+        currency: 'INR',
+        paymentMethod: 'upi',
+        failureType: 'one_time',
+        errorCode: 'GATEWAY_ERROR',
+        errorSource: 'gateway',
+        errorStep: 'authorization',
+        errorReason: 'timeout',
+        errorDescription: 'Gateway timeout',
+        createdAt: nowStr,
+      });
+      await db.insert(schema.recoveryJourneys).values({
+        id: journeyId,
+        customerId,
+        failureId,
+        status: 'recovering',
+        strategy: 'payment_link',
+        amountAtRisk: amount,
+        amountRecovered: 0,
+        maxAttempts: 3,
+        currentAttempt: 1,
+        createdAt: nowStr,
+        updatedAt: nowStr,
+      });
+      return journeyId;
+    }
+
+    const journeyA = await seedJourneyForCustomer(100000);
+    const journeyB = await seedJourneyForCustomer(250000);
+
+    await recoveryCoordinator.resolveJourneyWithPayment(journeyA, 'pay_a', 100000);
+    await recoveryCoordinator.resolveJourneyWithPayment(journeyB, 'pay_b', 250000);
+
+    const [customer] = await db.select().from(schema.customers).where(eq(schema.customers.id, customerId));
+    const journeys = await db.select().from(schema.recoveryJourneys).where(eq(schema.recoveryJourneys.customerId, customerId));
+    const expectedTotal = journeys.reduce((sum, j) => sum + j.amountRecovered, 0);
+
+    expect(customer.totalRecoveredAmount).toBe(expectedTotal);
+    expect(customer.totalRecoveredAmount).toBe(350000);
+  });
+});


### PR DESCRIPTION
## Summary
- `resolveJourneyWithPayment` had no guard against being called twice for the same journey: the journey status update was a set (idempotent) but `customers.totalRecoveredAmount` was an unconditional increment, so a retried webhook or replayed `/api/simulator/pay` request (currently unauthenticated — RA-05) could inflate the headline recovery figure without bound.
- Separately, the channel-effectiveness panel in `/api/metrics` filters `recovery_actions` on `outcome === 'payment_completed'`, but nothing ever wrote that value, so every channel always reported 0.0% conversion regardless of database state.
- Added an idempotency guard (`if (journey.status === 'resolved') return;`), attributed the conversion by setting `outcome: 'payment_completed'` on the journey's most recent action, and switched `totalRecoveredAmount` from an incrementing counter to a derived sum over the customer's journeys so it can't drift.

## Test plan
- [x] New `tests/resolution-idempotency.test.ts` (isolated on-disk DB, no race with `e2e-smoke.test.ts`): double-call leaves `totalRecoveredAmount` unchanged, exactly one `payment_recovered` audit entry across two calls, most-recent action gets `outcome: 'payment_completed'`, and `totalRecoveredAmount` always equals `SUM(amountRecovered)` across a customer's journeys.
- [x] `npm run typecheck` clean, `npm run lint` clean.
- [x] `npm test` — 53/53 passing, run 3x consecutively with no flakes.
- [x] Boundary-guardrail grep (`src/lib/recovery/`, `src/lib/ai/` vs `simulation`) — no violations.
- [x] `npm run build` — production build succeeds.

Closes #121
Closes #125
