### PR TITLE
fix: recover from failed webhook processing instead of swallowing retries

### DIFF
--- a/src/app/api/webhooks/razorpay/route.ts
+++ b/src/app/api/webhooks/razorpay/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { webhookEvents, paymentFailures, customers } from '@/lib/db/schema';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { verifyWebhookSignature, computePayloadHash } from '@/lib/razorpay/webhooks';
 import { RazorpayWebhookPayload } from '@/lib/razorpay/types';
 import { recoveryCoordinator } from '@/lib/recovery/coordinator';
@@ -11,6 +11,8 @@ import { formatIST, getClock } from '@/lib/utils/time';
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: NextRequest) {
+  let eventId: string | undefined;
+
   try {
     const rawBody = await req.text();
     const signature = req.headers.get('x-razorpay-signature') || '';
@@ -28,33 +30,66 @@ export async function POST(req: NextRequest) {
     }
 
     const payload = JSON.parse(rawBody) as RazorpayWebhookPayload & { id?: string };
-    const eventId = payload.id || `evt_${generateId('audit')}`;
+    eventId = payload.id || `evt_${generateId('audit')}`;
     const payloadHash = computePayloadHash(rawBody);
     const nowStr = formatIST(getClock().now());
 
-    // 1. Idempotency Check: Claim event in webhook_events table
-    const existingEvent = await db
-      .select()
-      .from(webhookEvents)
-      .where(eq(webhookEvents.id, eventId))
-      .limit(1);
+    // 1. Idempotency Claim: atomic insert-or-conflict on the primary key, so
+    // two concurrent deliveries of the same event can never both proceed
+    // (the previous select-then-insert was a TOCTOU race).
+    const claimed = await db
+      .insert(webhookEvents)
+      .values({
+        id: eventId,
+        eventType: payload.event,
+        payloadHash,
+        processingStatus: 'processing',
+        receivedAt: nowStr,
+      })
+      .onConflictDoNothing()
+      .returning();
 
-    if (existingEvent.length > 0) {
-      // Event has already been processed or is currently being processed
-      return NextResponse.json({
-        success: true,
-        data: { message: 'Duplicate webhook event ignored (idempotent)', eventId },
-      });
+    if (claimed.length === 0) {
+      const [prior] = await db
+        .select()
+        .from(webhookEvents)
+        .where(eq(webhookEvents.id, eventId))
+        .limit(1);
+
+      if (prior?.processingStatus === 'processed') {
+        // Only a genuinely completed event is a true duplicate.
+        return NextResponse.json({
+          success: true,
+          data: { message: 'Duplicate webhook event ignored (idempotent)', eventId },
+        });
+      }
+
+      if (prior?.processingStatus === 'failed') {
+        // A prior attempt errored out. Reclaim atomically (compare-and-swap
+        // on status) and reprocess this delivery instead of swallowing it.
+        const reclaimed = await db
+          .update(webhookEvents)
+          .set({ processingStatus: 'processing', errorMessage: null })
+          .where(and(eq(webhookEvents.id, eventId), eq(webhookEvents.processingStatus, 'failed')))
+          .returning();
+
+        if (reclaimed.length === 0) {
+          // Lost the reclaim race to another concurrent retry delivery.
+          return NextResponse.json(
+            { success: false, error: { code: 'RETRY', message: 'Event reprocessing already in progress' } },
+            { status: 503 }
+          );
+        }
+        // Falls through to process the event below.
+      } else {
+        // Still 'processing' — another delivery is actively working on it.
+        // Ask Razorpay to retry later rather than reporting false success.
+        return NextResponse.json(
+          { success: false, error: { code: 'RETRY', message: 'Event is currently being processed' } },
+          { status: 503 }
+        );
+      }
     }
-
-    // Insert as processing
-    await db.insert(webhookEvents).values({
-      id: eventId,
-      eventType: payload.event,
-      payloadHash,
-      processingStatus: 'processing',
-      receivedAt: nowStr,
-    });
 
     // 2. Process Event Types
     if (payload.event === 'payment.failed' && payload.payload.payment) {
@@ -127,6 +162,22 @@ export async function POST(req: NextRequest) {
   } catch (error: unknown) {
     const errorMsg = error instanceof Error ? error.message : 'Unknown webhook error';
     console.error('[POST /api/webhooks/razorpay]', error);
+
+    if (eventId) {
+      try {
+        await db
+          .update(webhookEvents)
+          .set({
+            processingStatus: 'failed',
+            errorMessage: errorMsg,
+            processedAt: formatIST(getClock().now()),
+          })
+          .where(eq(webhookEvents.id, eventId));
+      } catch (updateError) {
+        console.error('[POST /api/webhooks/razorpay] Failed to mark event as failed', updateError);
+      }
+    }
+
     return NextResponse.json(
       { success: false, error: { code: 'WEBHOOK_PROCESSING_ERROR', message: errorMsg } },
       { status: 500 }

--- a/tests/webhook-failed-state-recovery.test.ts
+++ b/tests/webhook-failed-state-recovery.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import crypto from 'crypto';
+import fs from 'fs';
+import { NextRequest } from 'next/server';
+
+// Isolate this suite onto its own on-disk DB file so it never races the
+// shared DB used by tests/e2e-smoke.test.ts (which truncates all tables in
+// its own beforeAll under Vitest's parallel-by-default file execution).
+const testDbPath = `./data/test-ra10-${crypto.randomUUID()}.db`;
+process.env.DATABASE_URL = `file:${testDbPath}`;
+
+const { db } = await import('../src/lib/db');
+const { webhookEvents, recoveryJourneys, paymentFailures } = await import('../src/lib/db/schema');
+const { eq } = await import('drizzle-orm');
+const { POST } = await import('../src/app/api/webhooks/razorpay/route');
+
+/**
+ * RA-10: a throw during processing must leave the webhook_events row at
+ * 'failed', not stuck at 'processing' forever, and a retry of a 'failed'
+ * event must actually reprocess it rather than being silently swallowed.
+ */
+describe('POST /api/webhooks/razorpay — failed-state recovery & idempotency (RA-10)', () => {
+  afterAll(() => {
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        fs.unlinkSync(testDbPath + suffix);
+      } catch {
+        // file may not exist
+      }
+    }
+  });
+
+  function buildBody(eventId: string, email: string, orderId: string) {
+    return JSON.stringify({
+      entity: 'event',
+      account_id: 'acc_test',
+      event: 'payment.failed',
+      contains: ['payment'],
+      created_at: Math.floor(Date.now() / 1000),
+      id: eventId,
+      payload: {
+        payment: {
+          entity: {
+            id: `pay_${crypto.randomUUID()}`,
+            amount: 49900,
+            currency: 'INR',
+            status: 'failed',
+            order_id: orderId,
+            method: 'card',
+            email,
+            contact: '+919876500001',
+            error_code: 'BAD_REQUEST_ERROR',
+            error_source: 'customer',
+            error_step: 'authorization',
+            error_reason: 'insufficient_funds',
+            error_description: 'Insufficient funds.',
+          },
+        },
+      },
+    });
+  }
+
+  function buildRequest(body: string) {
+    return new NextRequest('http://localhost/api/webhooks/razorpay', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+    });
+  }
+
+  it('marks the event failed (not stuck processing) when downstream processing throws', async () => {
+    const eventId = `evt_ra10_fail_${crypto.randomUUID()}`;
+    // Malformed payload: 'payment.failed' event with no `payload.payment` and no
+    // amount, causing the paymentFailures insert to violate its NOT NULL amount
+    // column and throw mid-processing.
+    const body = JSON.stringify({
+      entity: 'event',
+      event: 'payment.failed',
+      id: eventId,
+      payload: { payment: { entity: { id: 'pay_broken', order_id: 'order_broken', amount: null } } },
+    });
+
+    const res = await POST(buildRequest(body));
+    expect(res.status).toBe(500);
+
+    const [row] = await db.select().from(webhookEvents).where(eq(webhookEvents.id, eventId));
+    expect(row.processingStatus).toBe('failed');
+    expect(row.errorMessage).toBeTruthy();
+  });
+
+  it('reprocesses successfully on retry of a failed event', async () => {
+    const eventId = `evt_ra10_retry_${crypto.randomUUID()}`;
+    const brokenBody = JSON.stringify({
+      entity: 'event',
+      event: 'payment.failed',
+      id: eventId,
+      payload: { payment: { entity: { id: 'pay_broken2', order_id: 'order_broken2', amount: null } } },
+    });
+
+    const firstRes = await POST(buildRequest(brokenBody));
+    expect(firstRes.status).toBe(500);
+
+    const [failedRow] = await db.select().from(webhookEvents).where(eq(webhookEvents.id, eventId));
+    expect(failedRow.processingStatus).toBe('failed');
+
+    // Retry redelivery of the same event id, now with a well-formed payload
+    // (Razorpay resends the same event unmodified, but this proves the row
+    // is genuinely reprocessed rather than permanently swallowed).
+    const email = `ra10-retry-${crypto.randomUUID()}@example.com`;
+    const goodBody = buildBody(eventId, email, `order_${crypto.randomUUID()}`);
+
+    const secondRes = await POST(buildRequest(goodBody));
+    expect(secondRes.status).toBe(200);
+
+    const [processedRow] = await db.select().from(webhookEvents).where(eq(webhookEvents.id, eventId));
+    expect(processedRow.processingStatus).toBe('processed');
+
+    const journeys = await db.select().from(recoveryJourneys);
+    const failures = await db.select().from(paymentFailures);
+    expect(failures.some((f) => f.customerId)).toBe(true);
+    expect(journeys.length).toBeGreaterThan(0);
+  });
+
+  it('returns 200 with no side effects on retry of an already-processed event', async () => {
+    const eventId = `evt_ra10_dup_${crypto.randomUUID()}`;
+    const email = `ra10-dup-${crypto.randomUUID()}@example.com`;
+    const body = buildBody(eventId, email, `order_${crypto.randomUUID()}`);
+
+    const firstRes = await POST(buildRequest(body));
+    expect(firstRes.status).toBe(200);
+
+    const journeysAfterFirst = await db.select().from(recoveryJourneys);
+    const countAfterFirst = journeysAfterFirst.length;
+
+    const secondRes = await POST(buildRequest(body));
+    expect(secondRes.status).toBe(200);
+    const secondJson = await secondRes.json();
+    expect(secondJson.data.message).toMatch(/duplicate/i);
+
+    const journeysAfterSecond = await db.select().from(recoveryJourneys);
+    expect(journeysAfterSecond.length).toBe(countAfterFirst);
+  });
+
+  it('produces exactly one journey and no 500s from two concurrent deliveries of the same event', async () => {
+    const eventId = `evt_ra10_concurrent_${crypto.randomUUID()}`;
+    const email = `ra10-concurrent-${crypto.randomUUID()}@example.com`;
+    const orderId = `order_${crypto.randomUUID()}`;
+    const body = buildBody(eventId, email, orderId);
+
+    const [res1, res2] = await Promise.all([
+      POST(buildRequest(body)),
+      POST(buildRequest(body)),
+    ]);
+
+    const statuses = [res1.status, res2.status].sort();
+    // One request wins the claim (200); the other observes 'processing' and
+    // is told to retry (503) rather than getting a 500 or double-processing.
+    expect(statuses).toEqual([200, 503]);
+
+    const [failure] = await db
+      .select()
+      .from(paymentFailures)
+      .where(eq(paymentFailures.razorpayOrderId, orderId));
+    expect(failure).toBeDefined();
+
+    const journeys = await db.select().from(recoveryJourneys).where(eq(recoveryJourneys.failureId, failure.id));
+    expect(journeys.length).toBe(1);
+  });
+});

--- a/tests/webhook-failed-state-recovery.test.ts
+++ b/tests/webhook-failed-state-recovery.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import crypto from 'crypto';
 import fs from 'fs';
 import { NextRequest } from 'next/server';


### PR DESCRIPTION
## Summary
- The webhook route claimed an event by inserting a `'processing'` row before doing any work, then treated *any* existing row as a completed duplicate. A throw during processing (Gemini timeout, Razorpay 5xx) left the row stuck at `'processing'` forever — every subsequent Razorpay retry (the mechanism meant to heal exactly this) was answered with a false 200 and silently dropped.
- The claim itself was also a select-then-insert TOCTOU race: two concurrent deliveries of the same event could both pass the `select` and one would 500 on the primary-key violation.
- Fixed by claiming atomically (`insert().onConflictDoNothing().returning()`), only treating a `'processed'` row as a true duplicate, reclaiming a `'failed'` row via compare-and-swap and reprocessing it in the same request, returning 503 (not 500) when another delivery is actively `'processing'`, and marking the row `'failed'` with `errorMessage` in the catch block instead of leaving it stuck.
- Deliberately did **not** wrap the customer/failure/journey inserts in `db.transaction()` as the issue's proposed fix suggested — better-sqlite3's native `transaction()` requires a synchronous callback and cannot safely wrap the async Gemini/Razorpay calls inside `startRecoveryJourney`. Doing so would commit before that work resolves. Left as a separate follow-up; explained in the commit message.

## Test plan
- [x] New `tests/webhook-failed-state-recovery.test.ts` (isolated on-disk DB): a throw during processing marks the row `failed` with an error message; retrying a `failed` event reprocesses it successfully; retrying a `processed` event returns 200 with no new journey; two concurrent deliveries of the same event produce exactly one journey and no 500s (one 200, one 503).
- [x] `npm run typecheck` clean, `npm run lint` clean.
- [x] `npm test` — 53/53 passing, run 3x consecutively with no flakes.
- [x] Boundary-guardrail grep (`src/lib/recovery/`, `src/lib/ai/` vs `simulation`) — no violations.
- [x] `npm run build` — production build succeeds.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Razorpay webhook handling to prevent duplicate event processing.
  * Failed webhook events can now be retried successfully.
  * Events currently being processed return a retryable response.
  * Completed duplicate events return success without repeating actions.

* **Tests**
  * Added coverage for failure recovery, retries, duplicate deliveries, and concurrent webhook requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->