### PR TITLE
fix: abort recovery attempt instead of dispatching a fabricated payment link

### DIFF
--- a/src/app/api/simulator/reply/route.ts
+++ b/src/app/api/simulator/reply/route.ts
@@ -4,6 +4,7 @@ import { customers, recoveryJourneys, recoveryActions } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { processCustomerConversation } from '@/lib/ai/conversation';
 import { recoveryCoordinator } from '@/lib/recovery/coordinator';
+import { razorpayClient } from '@/lib/razorpay/client';
 import { generateId } from '@/lib/utils/ids';
 import { formatIST, getClock } from '@/lib/utils/time';
 import { writeAuditLog } from '@/lib/utils/audit';
@@ -45,8 +46,18 @@ export async function POST(req: NextRequest) {
     // 1. Process customer message through coordinator (handles stopping rules like STOP)
     await recoveryCoordinator.handleCustomerResponse(journey.id, message);
 
-    // 2. Generate contextual response via conversational agent
-    const paymentUrl = `https://rzp.io/i/recov_${journey.id}`;
+    // 2. Generate contextual response via conversational agent, resolving
+    // the real payment link short URL instead of a fabricated one (RA-14).
+    let paymentUrl = '';
+    if (journey.paymentLinkId) {
+      try {
+        const plink = await razorpayClient.getPaymentLink(journey.paymentLinkId);
+        paymentUrl = plink.short_url;
+      } catch (error) {
+        console.warn('[POST /api/simulator/reply] Failed to resolve payment link:', error);
+      }
+    }
+
     const conversationResult = await processCustomerConversation({
       customerName: customer?.name || 'Customer',
       customerMessage: message,

--- a/src/components/simulator/CustomerSimulator.tsx
+++ b/src/components/simulator/CustomerSimulator.tsx
@@ -120,6 +120,9 @@ export function CustomerSimulator({
   actions.forEach((action) => {
     // 1. Agent outreach message
     if (action.messageContent) {
+      // Show the "pay now" CTA only when the actual dispatched message
+      // contains a real link, instead of fabricating one (see RA-14).
+      const linkMatch = action.messageContent.match(/https?:\/\/\S+/);
       messages.push({
         id: `ra_agent_${action.id}`,
         sender: 'agent',
@@ -127,7 +130,7 @@ export function CustomerSimulator({
         content: action.messageContent,
         timestamp: action.executedAt || action.createdAt || '',
         deliveryStatus: action.deliveryStatus,
-        paymentLinkUrl: `https://rzp.io/i/recov_${journey?.id || 'demo'}`,
+        paymentLinkUrl: linkMatch?.[0],
         llmReasoning: action.llmReasoning || undefined,
         onPayClick: () => handlePay(),
       });

--- a/src/lib/recovery/coordinator.ts
+++ b/src/lib/recovery/coordinator.ts
@@ -184,9 +184,13 @@ export class RecoveryCoordinator {
     ) as RecoveryStrategy;
     const channel = getChannelForAttempt(strategy, nextAttempt);
 
-    // Generate Razorpay Payment Link
-    let paymentUrl = `https://rzp.io/i/recov_${journey.id}`;
-    let paymentLinkId = journey.paymentLinkId;
+    // Generate Razorpay Payment Link. A failure here must abort the attempt
+    // rather than degrade to a fabricated URL: a customer sent a dead link
+    // burns one of three attempts for nothing (see RA-14). Skipped attempts
+    // are recoverable on the next sweep; a spent attempt with a broken link
+    // is not.
+    let paymentUrl: string;
+    let paymentLinkId: string | null;
 
     try {
       const plink = await razorpayClient.createPaymentLink({
@@ -203,7 +207,18 @@ export class RecoveryCoordinator {
       paymentUrl = plink.short_url;
       paymentLinkId = plink.id;
     } catch (error) {
-      console.warn('[RecoveryCoordinator] Payment link generation fallback:', error);
+      console.warn('[RecoveryCoordinator] Payment link generation failed, aborting attempt:', error);
+      await writeAuditLog({
+        journeyId,
+        actor: 'system',
+        eventType: 'attempt_aborted',
+        eventData: {
+          reason: 'payment_link_unavailable',
+          attemptNumber: nextAttempt,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+      return;
     }
 
     // Generate personalized message via LLM

--- a/tests/payment-link-failure-abort.test.ts
+++ b/tests/payment-link-failure-abort.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, afterAll, afterEach, vi } from 'vitest';
+import crypto from 'crypto';
+import fs from 'fs';
+
+// Isolate this suite onto its own on-disk DB file so it never races the
+// shared DB used by tests/e2e-smoke.test.ts.
+const testDbPath = `./data/test-ra14-${crypto.randomUUID()}.db`;
+process.env.DATABASE_URL = `file:${testDbPath}`;
+
+const { db } = await import('../src/lib/db');
+const schema = await import('../src/lib/db/schema');
+const { eq } = await import('drizzle-orm');
+const { generateId } = await import('../src/lib/utils/ids');
+const { getClock, setClock, FixedClock, formatIST, SystemClock } = await import('../src/lib/utils/time');
+const { recoveryCoordinator } = await import('../src/lib/recovery/coordinator');
+const { razorpayClient } = await import('../src/lib/razorpay/client');
+
+async function seedJourney() {
+  const nowStr = formatIST(getClock().now());
+  const customerId = generateId('cust');
+  const failureId = generateId('fail');
+  const journeyId = generateId('rj');
+
+  await db.insert(schema.customers).values({
+    id: customerId,
+    name: 'Arjun Mehta',
+    email: `ra14-${crypto.randomUUID()}@example.com`,
+    phone: '+919800000077',
+    preferredLanguage: 'en',
+    segment: 'b2c',
+    totalFailures: 1,
+    totalRecoveredAmount: 0,
+    dndStatus: 'active',
+    createdAt: nowStr,
+    updatedAt: nowStr,
+  });
+
+  await db.insert(schema.paymentFailures).values({
+    id: failureId,
+    customerId,
+    razorpayPaymentId: 'pay_ra14',
+    razorpayOrderId: `order_ra14_${crypto.randomUUID()}`,
+    amount: 150000,
+    currency: 'INR',
+    paymentMethod: 'card',
+    failureType: 'one_time',
+    errorCode: 'BAD_REQUEST_ERROR',
+    errorSource: 'customer',
+    errorStep: 'authorization',
+    errorReason: 'insufficient_funds',
+    errorDescription: 'Insufficient funds',
+    createdAt: nowStr,
+  });
+
+  await db.insert(schema.recoveryJourneys).values({
+    id: journeyId,
+    customerId,
+    failureId,
+    status: 'recovering',
+    strategy: 'payment_link',
+    amountAtRisk: 150000,
+    amountRecovered: 0,
+    maxAttempts: 3,
+    currentAttempt: 0,
+    createdAt: nowStr,
+    updatedAt: nowStr,
+  });
+
+  return { customerId, journeyId };
+}
+
+describe('processRecoveryAttempt — aborts on payment-link failure instead of faking a URL (RA-14)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    setClock(new SystemClock());
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        fs.unlinkSync(testDbPath + suffix);
+      } catch {
+        // file may not exist
+      }
+    }
+  });
+
+  it('inserts no recovery_actions row and leaves currentAttempt unchanged when createPaymentLink throws', async () => {
+    setClock(new FixedClock('2026-08-21T14:30:00+05:30'));
+    const { journeyId } = await seedJourney();
+
+    vi.spyOn(razorpayClient, 'createPaymentLink').mockRejectedValueOnce(
+      new Error('Razorpay createPaymentLink failed (500): gateway timeout')
+    );
+
+    await recoveryCoordinator.processRecoveryAttempt(journeyId);
+
+    const actions = await db
+      .select()
+      .from(schema.recoveryActions)
+      .where(eq(schema.recoveryActions.journeyId, journeyId));
+    expect(actions.length).toBe(0);
+
+    const [journey] = await db
+      .select()
+      .from(schema.recoveryJourneys)
+      .where(eq(schema.recoveryJourneys.id, journeyId));
+    expect(journey.currentAttempt).toBe(0);
+    expect(journey.status).toBe('recovering');
+  });
+
+  it('writes an attempt_aborted audit entry when createPaymentLink throws', async () => {
+    setClock(new FixedClock('2026-08-21T14:30:00+05:30'));
+    const { journeyId } = await seedJourney();
+
+    vi.spyOn(razorpayClient, 'createPaymentLink').mockRejectedValueOnce(new Error('network error'));
+
+    await recoveryCoordinator.processRecoveryAttempt(journeyId);
+
+    const logs = await db.select().from(schema.auditLogs).where(eq(schema.auditLogs.journeyId, journeyId));
+    const aborted = logs.filter((l) => l.eventType === 'attempt_aborted');
+    expect(aborted.length).toBe(1);
+    const eventData = JSON.parse(aborted[0].eventData);
+    expect(eventData.reason).toBe('payment_link_unavailable');
+  });
+
+  it('the next sweep succeeds and dispatches once the payment-link API recovers', async () => {
+    setClock(new FixedClock('2026-08-21T14:30:00+05:30'));
+    const { journeyId } = await seedJourney();
+
+    vi.spyOn(razorpayClient, 'createPaymentLink').mockRejectedValueOnce(new Error('transient failure'));
+    await recoveryCoordinator.processRecoveryAttempt(journeyId);
+
+    let actions = await db.select().from(schema.recoveryActions).where(eq(schema.recoveryActions.journeyId, journeyId));
+    expect(actions.length).toBe(0);
+
+    // Next sweep, API is healthy again (no mock override this time).
+    await recoveryCoordinator.processRecoveryAttempt(journeyId);
+
+    actions = await db.select().from(schema.recoveryActions).where(eq(schema.recoveryActions.journeyId, journeyId));
+    expect(actions.length).toBe(1);
+    expect(actions[0].attemptNumber).toBe(1);
+
+    const [journey] = await db.select().from(schema.recoveryJourneys).where(eq(schema.recoveryJourneys.id, journeyId));
+    expect(journey.currentAttempt).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- When Razorpay's payment-link API failed, the coordinator logged a warning and fell through to dispatch the outreach message anyway, pointing at a fabricated `https://rzp.io/i/recov_<journey.id>` URL that resolves to nothing — a customer received a payment request with a dead, Razorpay-branded 404 link, burning one of only three recovery attempts.
- `processRecoveryAttempt` now aborts the attempt on a `createPaymentLink` failure: no `recovery_actions` row is inserted, `currentAttempt` is left unchanged, and an `attempt_aborted` audit entry records the reason so the next sweep can retry cleanly.
- Removed the same hardcoded fallback in `src/app/api/simulator/reply/route.ts` — it now resolves the real short URL via `razorpayClient.getPaymentLink(journey.paymentLinkId)`.
- Removed a third instance in `CustomerSimulator.tsx` that fabricated a URL just to decide whether to show the "pay now" CTA in the chat UI; it now derives the link (if any) from the actual dispatched `messageContent`, which already carries the real, validated link.

## Test plan
- [x] New `tests/payment-link-failure-abort.test.ts` (isolated on-disk DB, `vi.spyOn` on `razorpayClient.createPaymentLink`): a `createPaymentLink` throw inserts no action row and leaves `currentAttempt` unchanged; writes exactly one `attempt_aborted` audit entry with `reason: 'payment_link_unavailable'`; the next sweep succeeds and dispatches once the API recovers.
- [x] `grep -rn "rzp.io/i/recov_" src/` — only the legitimate mock-mode simulated response in `razorpay/client.ts` remains (consistent with every other mocked field there); no fallback-on-failure literal remains.
- [x] `npm run typecheck` clean, `npm run lint` clean.
- [x] `npm test` — 52/52 passing, run 3x consecutively with no flakes.
- [x] Boundary-guardrail grep (`src/lib/recovery/`, `src/lib/ai/` vs `simulation`) — no violations.
- [x] `npm run build` — production build succeeds.

Closes #126

