### PR TITLE
fix: tighten the dependency audit gate to actually gate

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,5 +40,4 @@ jobs:
           cache: 'npm'
 
       - name: Run npm Audit
-        run: npm audit --audit-level=critical
-        continue-on-error: true
+        run: npm audit --audit-level=high --omit=dev


### PR DESCRIPTION
## Summary
- `npm audit --audit-level=critical` meant high and moderate advisories never broke the build, and `continue-on-error: true` on top of that meant even a real failure wouldn't have blocked CI anyway — the gate existed in name only.
- Currently there are 4 moderate advisories, all `esbuild` reachable through `drizzle-kit` (a devDependency, not shipped to production).
- Tightened to `npm audit --audit-level=high --omit=dev` so CI fails on high/critical advisories in **production** dependencies specifically, without blocking on the existing dev-only moderates.
- Removed `continue-on-error` so a real failure actually fails the job.

## Test plan
- [x] Ran the exact new command locally against the current lockfile: `npm audit --audit-level=high --omit=dev` → `found 0 vulnerabilities`, exit code 0.
- [x] Confirmed the 4 existing moderate advisories are dev-only (`npm audit --omit=dev` reports 0; full `npm audit` shows all 4 trace through `drizzle-kit`'s `esbuild` dependency).
- [x] Validated YAML syntax.
- [x] `npm run typecheck` clean, `npm run lint` clean, `npm test` — 49/49 passing (this branch carries no other fixes), `npm run build` succeeds.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)