### PR TITLE
fix: require session auth on dashboard routes, close every anonymous path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,22 @@ DATABASE_URL=file:./data/recoverai.db
 
 # Application Configuration
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Dashboard Authentication (RA-05)
+# Required to log in to / and /customers /metrics /api/customers etc.
+# Change these before any non-local deployment.
+SESSION_SECRET=XXXXXXXXXXXXXXXXXXXXXXXX
+DASHBOARD_USERNAME=admin
+DASHBOARD_PASSWORD=XXXXXXXXXXXXXXXXXXXXXXXX
+
+# Shared secret an external cron/scheduler presents (as `Authorization:
+# Bearer <secret>` or `x-recovery-secret: <secret>`) to call
+# /api/recovery/trigger and /api/recovery/sweep without a dashboard session.
+# Required for those routes to accept unauthenticated (non-session) callers;
+# they return 503 if this is unset and no session is presented.
+RECOVERY_SWEEP_SECRET=XXXXXXXXXXXXXXXXXXXXXXXX
+
+# Demo-mode flag: when 'true', /api/simulator/* is publicly reachable
+# (no session required) for demoing the customer chat/payment simulator.
+# Leave unset ('false') outside of local/demo deployments.
+RECOVERAI_DEMO_MODE=true

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { timingSafeStringEqual } from '@/lib/auth/crypto';
+import { createSessionToken, SESSION_COOKIE_NAME, SESSION_MAX_AGE_SECONDS } from '@/lib/auth/session';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => null);
+    const username = typeof body?.username === 'string' ? body.username : '';
+    const password = typeof body?.password === 'string' ? body.password : '';
+
+    const configuredUsername = process.env.DASHBOARD_USERNAME || '';
+    const configuredPassword = process.env.DASHBOARD_PASSWORD || '';
+
+    if (!configuredUsername || !configuredPassword || !process.env.SESSION_SECRET) {
+      return NextResponse.json(
+        { success: false, error: { code: 'NOT_CONFIGURED', message: 'Dashboard login is not configured' } },
+        { status: 503 }
+      );
+    }
+
+    const usernameMatches = username.length > 0 && timingSafeStringEqual(username, configuredUsername);
+    const passwordMatches = password.length > 0 && timingSafeStringEqual(password, configuredPassword);
+
+    if (!usernameMatches || !passwordMatches) {
+      return NextResponse.json(
+        { success: false, error: { code: 'INVALID_CREDENTIALS', message: 'Invalid username or password' } },
+        { status: 401 }
+      );
+    }
+
+    const token = createSessionToken(configuredUsername);
+    if (!token) {
+      return NextResponse.json(
+        { success: false, error: { code: 'NOT_CONFIGURED', message: 'Dashboard login is not configured' } },
+        { status: 503 }
+      );
+    }
+
+    const res = NextResponse.json({ success: true, data: { message: 'Logged in' } });
+    res.cookies.set(SESSION_COOKIE_NAME, token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: SESSION_MAX_AGE_SECONDS,
+    });
+    return res;
+  } catch (error: unknown) {
+    console.error('[POST /api/auth/login]', error);
+    return NextResponse.json(
+      { success: false, error: { code: 'LOGIN_ERROR', message: 'Login failed' } },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { SESSION_COOKIE_NAME } from '@/lib/auth/session';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST() {
+  const res = NextResponse.json({ success: true, data: { message: 'Logged out' } });
+  res.cookies.set(SESSION_COOKIE_NAME, '', { path: '/', maxAge: 0 });
+  return res;
+}

--- a/src/app/api/recovery/sweep/route.ts
+++ b/src/app/api/recovery/sweep/route.ts
@@ -1,25 +1,13 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { runCheckoutAbandonmentSweep } from '@/lib/recovery/abandonment-sweep';
 
 export const dynamic = 'force-dynamic';
 
-export async function POST(req: NextRequest) {
+// Authorization (dashboard session or cron secret, failing closed if the
+// secret is unconfigured) is enforced in src/proxy.ts before this handler
+// ever runs — see RA-05.
+export async function POST() {
   try {
-    // Optional cron/shared-secret check if configured in environment
-    const configuredSecret = process.env.RECOVERY_SWEEP_SECRET || process.env.CRON_SECRET;
-    if (configuredSecret) {
-      const authHeader = req.headers.get('authorization');
-      const secretHeader = req.headers.get('x-recovery-secret');
-      const token = authHeader?.replace(/^Bearer\s+/i, '') || secretHeader;
-
-      if (!token || token !== configuredSecret) {
-        return NextResponse.json(
-          { success: false, error: { code: 'UNAUTHORIZED', message: 'Invalid or missing sweep secret' } },
-          { status: 401 }
-        );
-      }
-    }
-
     const result = await runCheckoutAbandonmentSweep();
     return NextResponse.json({
       success: true,

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense } from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Sparkles, Loader2, ShieldAlert } from 'lucide-react';
+
+function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const nextPath = searchParams.get('next') || '/';
+
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+      const json = await res.json();
+
+      if (json.success) {
+        router.push(nextPath);
+        router.refresh();
+      } else {
+        setError(json.error?.message || 'Login failed');
+      }
+    } catch {
+      setError('Could not reach the server. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-zinc-50/60 dark:bg-zinc-950 px-4">
+      <Card className="w-full max-w-sm border-zinc-200 dark:border-zinc-800 shadow-xs">
+        <CardHeader className="text-center space-y-2">
+          <div className="w-10 h-10 mx-auto rounded-xl bg-gradient-to-tr from-blue-600 via-indigo-600 to-violet-600 flex items-center justify-center text-white shadow-md shadow-indigo-500/20">
+            <Sparkles className="w-5 h-5" />
+          </div>
+          <CardTitle className="text-lg font-bold text-zinc-900 dark:text-zinc-50">
+            Recover<span className="text-indigo-600 dark:text-indigo-400">AI</span> Dashboard
+          </CardTitle>
+          <CardDescription className="text-xs text-zinc-500">
+            Sign in to view customer records, metrics, and run recovery.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <Input
+              type="text"
+              placeholder="Username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              autoComplete="username"
+              required
+            />
+            <Input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoComplete="current-password"
+              required
+            />
+
+            {error && (
+              <div className="flex items-start gap-2 text-xs text-rose-600 dark:text-rose-400 bg-rose-50 dark:bg-rose-950/30 rounded-lg p-2.5">
+                <ShieldAlert className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+                <span>{error}</span>
+              </div>
+            )}
+
+            <Button type="submit" disabled={isSubmitting} className="w-full bg-indigo-600 hover:bg-indigo-700 text-white">
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Signing in...
+                </>
+              ) : (
+                'Sign in'
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
+  );
+}

--- a/src/components/navigation/Navbar.tsx
+++ b/src/components/navigation/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -14,10 +14,12 @@ import {
   Clock,
   Sparkles,
   Loader2,
+  LogOut,
 } from 'lucide-react';
 
 export function Navbar() {
   const pathname = usePathname();
+  const router = useRouter();
   const [isSeeding, setIsSeeding] = useState(false);
   const [isRecovering, setIsRecovering] = useState(false);
   const [istTime, setIstTime] = useState<string>('');
@@ -79,6 +81,15 @@ export function Navbar() {
       console.error('Run agent error:', err);
     } finally {
       setIsRecovering(false);
+    }
+  };
+
+  const handleLogout = async () => {
+    try {
+      await fetch('/api/auth/logout', { method: 'POST' });
+    } finally {
+      router.push('/login');
+      router.refresh();
     }
   };
 
@@ -195,6 +206,17 @@ export function Navbar() {
                 Run AI Agent
               </>
             )}
+          </Button>
+
+          {/* Log out of the dashboard session */}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleLogout}
+            className="text-xs font-medium text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100"
+          >
+            <LogOut className="w-3.5 h-3.5 mr-1.5" />
+            Log out
           </Button>
         </div>
       </div>

--- a/src/lib/auth/crypto.ts
+++ b/src/lib/auth/crypto.ts
@@ -1,0 +1,16 @@
+import crypto from 'crypto';
+
+/**
+ * Constant-time string comparison. Length is checked first (a length
+ * mismatch is public information, not something worth hiding), then the
+ * actual bytes are compared via crypto.timingSafeEqual so a byte-by-byte
+ * timing oracle can't be used to guess a secret one character at a time.
+ */
+export function timingSafeStringEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a);
+  const bBuf = Buffer.from(b);
+  if (aBuf.length !== bBuf.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(aBuf, bBuf);
+}

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,0 +1,58 @@
+import crypto from 'crypto';
+
+export const SESSION_COOKIE_NAME = 'recoverai_session';
+const SESSION_TTL_MS = 12 * 60 * 60 * 1000; // 12 hours
+export const SESSION_MAX_AGE_SECONDS = SESSION_TTL_MS / 1000;
+
+/**
+ * Stateless, signed session cookie: base64url(payload) + '.' +
+ * HMAC-SHA256(payload, SESSION_SECRET). No server-side session store is
+ * needed — the signature and embedded expiry are the whole trust boundary.
+ */
+
+function getSessionSecret(): string | null {
+  const secret = process.env.SESSION_SECRET;
+  return secret && secret.length > 0 ? secret : null;
+}
+
+export function isSessionConfigured(): boolean {
+  return getSessionSecret() !== null;
+}
+
+export function createSessionToken(username: string): string | null {
+  const secret = getSessionSecret();
+  if (!secret) return null;
+
+  const payload = JSON.stringify({ u: username, exp: Date.now() + SESSION_TTL_MS });
+  const payloadB64 = Buffer.from(payload, 'utf-8').toString('base64url');
+  const signature = crypto.createHmac('sha256', secret).update(payloadB64).digest('base64url');
+  return `${payloadB64}.${signature}`;
+}
+
+export function verifySessionToken(token: string | undefined | null): boolean {
+  if (!token) return false;
+
+  const secret = getSessionSecret();
+  if (!secret) return false;
+
+  const parts = token.split('.');
+  if (parts.length !== 2) return false;
+  const [payloadB64, signature] = parts;
+
+  const expectedSig = crypto.createHmac('sha256', secret).update(payloadB64).digest('base64url');
+  const sigBuf = Buffer.from(signature);
+  const expectedBuf = Buffer.from(expectedSig);
+  if (sigBuf.length !== expectedBuf.length || !crypto.timingSafeEqual(sigBuf, expectedBuf)) {
+    return false;
+  }
+
+  try {
+    const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf-8')) as {
+      u?: unknown;
+      exp?: unknown;
+    };
+    return typeof payload.exp === 'number' && payload.exp > Date.now();
+  } catch {
+    return false;
+  }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { checkRateLimit } from '@/lib/utils/rate-limit';
+import { timingSafeStringEqual } from '@/lib/auth/crypto';
+import { isSessionConfigured, verifySessionToken, SESSION_COOKIE_NAME } from '@/lib/auth/session';
 
 // Reject oversized bodies before any parsing/hashing work happens (see
 // RA-20). This is a first-line check on the declared Content-Length, not a
@@ -7,31 +9,126 @@ import { checkRateLimit } from '@/lib/utils/rate-limit';
 // (e.g. chunked transfer-encoding) isn't caught here.
 const MAX_BODY_BYTES = 64 * 1024;
 
-export function proxy(req: NextRequest): NextResponse {
-  const contentLength = Number(req.headers.get('content-length') ?? 0);
-  if (contentLength > MAX_BODY_BYTES) {
-    return NextResponse.json(
-      { success: false, error: { code: 'PAYLOAD_TOO_LARGE', message: 'Request body exceeds 64KB limit' } },
-      { status: 413 }
-    );
+function unauthorizedJson(message: string) {
+  return NextResponse.json({ success: false, error: { code: 'UNAUTHORIZED', message } }, { status: 401 });
+}
+
+function unavailableJson(message: string) {
+  return NextResponse.json({ success: false, error: { code: 'NOT_CONFIGURED', message } }, { status: 503 });
+}
+
+function hasValidSession(req: NextRequest): boolean {
+  return verifySessionToken(req.cookies.get(SESSION_COOKIE_NAME)?.value);
+}
+
+function hasValidCronSecret(req: NextRequest): { configured: boolean; valid: boolean } {
+  const configuredSecret = process.env.RECOVERY_SWEEP_SECRET || process.env.CRON_SECRET || '';
+  if (!configuredSecret) {
+    return { configured: false, valid: false };
   }
 
-  const ip =
-    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
-    req.headers.get('x-real-ip') ||
-    'unknown';
+  const authHeader = req.headers.get('authorization');
+  const secretHeader = req.headers.get('x-recovery-secret');
+  const token = authHeader?.replace(/^Bearer\s+/i, '') || secretHeader || '';
 
-  const { allowed, retryAfterSeconds } = checkRateLimit(ip);
-  if (!allowed) {
-    return NextResponse.json(
-      { success: false, error: { code: 'RATE_LIMITED', message: 'Too many requests' } },
-      { status: 429, headers: { 'Retry-After': String(retryAfterSeconds) } }
-    );
+  return { configured: true, valid: token.length > 0 && timingSafeStringEqual(token, configuredSecret) };
+}
+
+export function proxy(req: NextRequest): NextResponse {
+  const { pathname } = req.nextUrl;
+  const isApiRoute = pathname.startsWith('/api/');
+
+  if (isApiRoute) {
+    const contentLength = Number(req.headers.get('content-length') ?? 0);
+    if (contentLength > MAX_BODY_BYTES) {
+      return NextResponse.json(
+        { success: false, error: { code: 'PAYLOAD_TOO_LARGE', message: 'Request body exceeds 64KB limit' } },
+        { status: 413 }
+      );
+    }
+
+    const ip =
+      req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      req.headers.get('x-real-ip') ||
+      'unknown';
+
+    const { allowed, retryAfterSeconds } = checkRateLimit(ip);
+    if (!allowed) {
+      return NextResponse.json(
+        { success: false, error: { code: 'RATE_LIMITED', message: 'Too many requests' } },
+        { status: 429, headers: { 'Retry-After': String(retryAfterSeconds) } }
+      );
+    }
+  }
+
+  // The Razorpay webhook authenticates itself with an HMAC signature (see
+  // RA-01) and login/logout must be reachable while unauthenticated — both
+  // are exempt from the session/secret tiering below.
+  if (pathname.startsWith('/api/webhooks/') || pathname.startsWith('/api/auth/')) {
+    return NextResponse.next();
+  }
+
+  // /api/simulator/*: a public demo tool, gated on demo mode rather than a
+  // session, matching the existing RECOVERAI_DEMO_MODE convention.
+  if (pathname.startsWith('/api/simulator/')) {
+    if (process.env.RECOVERAI_DEMO_MODE !== 'true') {
+      return NextResponse.json(
+        { success: false, error: { code: 'NOT_FOUND', message: 'Not found' } },
+        { status: 404 }
+      );
+    }
+    return NextResponse.next();
+  }
+
+  // /api/recovery/*: the dashboard's own "Run Recovery"/"Sweep" buttons call
+  // these directly, so a valid dashboard session is accepted, in addition to
+  // the cron secret for external schedulers. Unlike the old sweep route, an
+  // unconfigured secret with no session now fails closed (503), not open.
+  if (pathname.startsWith('/api/recovery/')) {
+    if (hasValidSession(req)) {
+      return NextResponse.next();
+    }
+    const cron = hasValidCronSecret(req);
+    if (cron.valid) {
+      return NextResponse.next();
+    }
+    if (!cron.configured) {
+      return unavailableJson('Recovery endpoint has no cron secret configured and no session was presented');
+    }
+    return unauthorizedJson('Invalid or missing recovery secret');
+  }
+
+  if (isApiRoute) {
+    // Every other /api/* route (customers, metrics, ...) is dashboard data:
+    // require a valid session.
+    if (!hasValidSession(req)) {
+      return unauthorizedJson('Authentication required');
+    }
+    return NextResponse.next();
+  }
+
+  // Page routes: allow the login page itself and Next.js internals through
+  // unauthenticated; redirect everything else to /login when there's no
+  // valid session.
+  if (pathname === '/login') {
+    return NextResponse.next();
+  }
+
+  if (!hasValidSession(req)) {
+    if (!isSessionConfigured()) {
+      // Login isn't configured at all (SESSION_SECRET missing) — don't trap
+      // the operator in an unusable redirect loop; let pages render so the
+      // misconfiguration is visible instead of silently redirecting forever.
+      return NextResponse.next();
+    }
+    const loginUrl = new URL('/login', req.url);
+    loginUrl.searchParams.set('next', pathname);
+    return NextResponse.redirect(loginUrl);
   }
 
   return NextResponse.next();
 }
 
 export const config = {
-  matcher: '/api/:path*',
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|.*\\..*).*)'],
 };

--- a/tests/auth-login-route.test.ts
+++ b/tests/auth-login-route.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST as login } from '../src/app/api/auth/login/route';
+import { POST as logout } from '../src/app/api/auth/logout/route';
+import { SESSION_COOKIE_NAME, verifySessionToken } from '../src/lib/auth/session';
+
+function buildLoginRequest(body: unknown) {
+  return new NextRequest('http://localhost/api/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/auth/login (RA-05)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns 503 when login is not configured', async () => {
+    vi.stubEnv('DASHBOARD_USERNAME', '');
+    vi.stubEnv('DASHBOARD_PASSWORD', '');
+    vi.stubEnv('SESSION_SECRET', '');
+
+    const res = await login(buildLoginRequest({ username: 'admin', password: 'anything' }));
+    expect(res.status).toBe(503);
+  });
+
+  it('rejects wrong credentials with 401 and sets no cookie', async () => {
+    vi.stubEnv('DASHBOARD_USERNAME', 'admin');
+    vi.stubEnv('DASHBOARD_PASSWORD', 'correct-horse-battery-staple');
+    vi.stubEnv('SESSION_SECRET', 'test-secret');
+
+    const res = await login(buildLoginRequest({ username: 'admin', password: 'wrong' }));
+    expect(res.status).toBe(401);
+    expect(res.headers.get('set-cookie')).toBeNull();
+  });
+
+  it('accepts correct credentials and sets a valid, httpOnly session cookie', async () => {
+    vi.stubEnv('DASHBOARD_USERNAME', 'admin');
+    vi.stubEnv('DASHBOARD_PASSWORD', 'correct-horse-battery-staple');
+    vi.stubEnv('SESSION_SECRET', 'test-secret');
+
+    const res = await login(buildLoginRequest({ username: 'admin', password: 'correct-horse-battery-staple' }));
+    expect(res.status).toBe(200);
+
+    const setCookie = res.headers.get('set-cookie') || '';
+    expect(setCookie).toContain(SESSION_COOKIE_NAME);
+    expect(setCookie.toLowerCase()).toContain('httponly');
+
+    const tokenMatch = setCookie.match(new RegExp(`${SESSION_COOKIE_NAME}=([^;]+)`));
+    expect(tokenMatch).toBeTruthy();
+    expect(verifySessionToken(tokenMatch![1])).toBe(true);
+  });
+
+  it('rejects a non-string username/password payload without throwing', async () => {
+    vi.stubEnv('DASHBOARD_USERNAME', 'admin');
+    vi.stubEnv('DASHBOARD_PASSWORD', 'correct-horse-battery-staple');
+    vi.stubEnv('SESSION_SECRET', 'test-secret');
+
+    const res = await login(buildLoginRequest({ username: 12345, password: null }));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /api/auth/logout (RA-05)', () => {
+  it('clears the session cookie', async () => {
+    const res = await logout();
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.get('set-cookie') || '';
+    expect(setCookie).toContain(SESSION_COOKIE_NAME);
+    expect(setCookie).toMatch(/Max-Age=0/i);
+  });
+});

--- a/tests/auth-session.test.ts
+++ b/tests/auth-session.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { timingSafeStringEqual } from '../src/lib/auth/crypto';
+import { createSessionToken, verifySessionToken, isSessionConfigured } from '../src/lib/auth/session';
+
+describe('timingSafeStringEqual', () => {
+  it('returns true for identical strings', () => {
+    expect(timingSafeStringEqual('secret123', 'secret123')).toBe(true);
+  });
+
+  it('returns false for different strings of the same length', () => {
+    expect(timingSafeStringEqual('secret123', 'secret124')).toBe(false);
+  });
+
+  it('returns false for different-length strings without throwing', () => {
+    expect(timingSafeStringEqual('short', 'a-much-longer-string')).toBe(false);
+  });
+});
+
+describe('session token creation and verification', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('reports unconfigured when SESSION_SECRET is unset', () => {
+    vi.stubEnv('SESSION_SECRET', '');
+    expect(isSessionConfigured()).toBe(false);
+    expect(createSessionToken('admin')).toBeNull();
+  });
+
+  it('creates and verifies a valid token', () => {
+    vi.stubEnv('SESSION_SECRET', 'test-secret-a');
+    const token = createSessionToken('admin');
+    expect(token).toBeTruthy();
+    expect(verifySessionToken(token)).toBe(true);
+  });
+
+  it('rejects a token signed with a different secret', () => {
+    vi.stubEnv('SESSION_SECRET', 'test-secret-a');
+    const token = createSessionToken('admin');
+
+    vi.stubEnv('SESSION_SECRET', 'test-secret-b');
+    expect(verifySessionToken(token)).toBe(false);
+  });
+
+  it('rejects a tampered payload', () => {
+    vi.stubEnv('SESSION_SECRET', 'test-secret-a');
+    const token = createSessionToken('admin')!;
+    const [payload, signature] = token.split('.');
+    const tamperedPayload = Buffer.from(JSON.stringify({ u: 'attacker', exp: Date.now() + 999999 }), 'utf-8').toString(
+      'base64url'
+    );
+    expect(verifySessionToken(`${tamperedPayload}.${signature}`)).toBe(false);
+    void payload;
+  });
+
+  it('rejects an expired token', () => {
+    vi.stubEnv('SESSION_SECRET', 'test-secret-a');
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now - 13 * 60 * 60 * 1000); // 13h ago, TTL is 12h
+    const token = createSessionToken('admin');
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    expect(verifySessionToken(token)).toBe(false);
+    vi.restoreAllMocks();
+  });
+
+  it('rejects malformed tokens', () => {
+    vi.stubEnv('SESSION_SECRET', 'test-secret-a');
+    expect(verifySessionToken('not-a-real-token')).toBe(false);
+    expect(verifySessionToken(null)).toBe(false);
+    expect(verifySessionToken(undefined)).toBe(false);
+  });
+});

--- a/tests/proxy-auth.test.ts
+++ b/tests/proxy-auth.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import crypto from 'crypto';
+import { NextRequest } from 'next/server';
+import { proxy } from '../src/proxy';
+import { resetRateLimitState } from '../src/lib/utils/rate-limit';
+import { createSessionToken, SESSION_COOKIE_NAME } from '../src/lib/auth/session';
+
+const SESSION_SECRET = 'ra05-test-session-secret';
+
+function buildRequest(path: string, opts: { cookie?: string; headers?: Record<string, string>; ip?: string } = {}) {
+  const headers: Record<string, string> = { ...opts.headers };
+  if (opts.cookie) headers['cookie'] = opts.cookie;
+  if (opts.ip) headers['x-forwarded-for'] = opts.ip;
+
+  return new NextRequest(`http://localhost${path}`, { headers });
+}
+
+function sessionCookie() {
+  const token = createSessionToken('admin');
+  return `${SESSION_COOKIE_NAME}=${token}`;
+}
+
+describe('proxy — dashboard read routes require a session (RA-05)', () => {
+  beforeEach(() => {
+    resetRateLimitState();
+    vi.stubEnv('SESSION_SECRET', SESSION_SECRET);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('rejects /api/customers with 401 when no session cookie is present', () => {
+    const res = proxy(buildRequest('/api/customers', { ip: `10.0.0.${crypto.randomUUID().slice(0, 2)}` }));
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects /api/metrics with 401 for a tampered session cookie', () => {
+    const res = proxy(
+      buildRequest('/api/metrics', {
+        cookie: `${SESSION_COOKIE_NAME}=not.a.valid.token`,
+        ip: `10.0.1.${crypto.randomUUID().slice(0, 2)}`,
+      })
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('allows /api/customers through with a valid session cookie', () => {
+    const res = proxy(
+      buildRequest('/api/customers', { cookie: sessionCookie(), ip: `10.0.2.${crypto.randomUUID().slice(0, 2)}` })
+    );
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(403);
+  });
+});
+
+describe('proxy — /api/simulator/* gated on demo mode, not session (RA-05)', () => {
+  beforeEach(() => {
+    resetRateLimitState();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns 404 when demo mode is off, even with no session', () => {
+    vi.stubEnv('RECOVERAI_DEMO_MODE', 'false');
+    const res = proxy(buildRequest('/api/simulator/seed', { ip: `10.0.3.${crypto.randomUUID().slice(0, 2)}` }));
+    expect(res.status).toBe(404);
+  });
+
+  it('passes through with no session required when demo mode is on', () => {
+    vi.stubEnv('RECOVERAI_DEMO_MODE', 'true');
+    const res = proxy(buildRequest('/api/simulator/seed', { ip: `10.0.4.${crypto.randomUUID().slice(0, 2)}` }));
+    expect(res.status).not.toBe(404);
+    expect(res.status).not.toBe(401);
+  });
+});
+
+describe('proxy — /api/recovery/* accepts a session or a cron secret, fails closed (RA-05)', () => {
+  beforeEach(() => {
+    resetRateLimitState();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns 503 (not 200) when unconfigured and no session is presented', () => {
+    vi.stubEnv('RECOVERY_SWEEP_SECRET', '');
+    vi.stubEnv('CRON_SECRET', '');
+    const res = proxy(buildRequest('/api/recovery/sweep', { ip: `10.0.5.${crypto.randomUUID().slice(0, 2)}` }));
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 401 for a wrong secret when configured', () => {
+    vi.stubEnv('RECOVERY_SWEEP_SECRET', 'correct-secret');
+    const res = proxy(
+      buildRequest('/api/recovery/trigger', {
+        headers: { 'x-recovery-secret': 'wrong-secret' },
+        ip: `10.0.6.${crypto.randomUUID().slice(0, 2)}`,
+      })
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('passes through with the correct cron secret and no session', () => {
+    vi.stubEnv('RECOVERY_SWEEP_SECRET', 'correct-secret');
+    const res = proxy(
+      buildRequest('/api/recovery/trigger', {
+        headers: { authorization: 'Bearer correct-secret' },
+        ip: `10.0.7.${crypto.randomUUID().slice(0, 2)}`,
+      })
+    );
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(503);
+  });
+
+  it('passes through with a valid dashboard session even with no secret configured', () => {
+    vi.stubEnv('SESSION_SECRET', SESSION_SECRET);
+    vi.stubEnv('RECOVERY_SWEEP_SECRET', '');
+    vi.stubEnv('CRON_SECRET', '');
+    const res = proxy(
+      buildRequest('/api/recovery/trigger', { cookie: sessionCookie(), ip: `10.0.8.${crypto.randomUUID().slice(0, 2)}` })
+    );
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(503);
+  });
+});
+
+describe('proxy — webhook and auth routes are exempt from session/secret tiering (RA-05)', () => {
+  beforeEach(() => {
+    resetRateLimitState();
+  });
+
+  it('lets an unauthenticated request through to the webhook route (it has its own HMAC check)', () => {
+    const res = proxy(buildRequest('/api/webhooks/razorpay', { ip: `10.0.9.${crypto.randomUUID().slice(0, 2)}` }));
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(404);
+    expect(res.status).not.toBe(503);
+  });
+
+  it('lets an unauthenticated request through to /api/auth/login (otherwise no one could log in)', () => {
+    const res = proxy(buildRequest('/api/auth/login', { ip: `10.0.10.${crypto.randomUUID().slice(0, 2)}` }));
+    expect(res.status).not.toBe(401);
+  });
+});
+
+describe('proxy — dashboard pages redirect to /login without a session (RA-05)', () => {
+  beforeEach(() => {
+    resetRateLimitState();
+    vi.stubEnv('SESSION_SECRET', SESSION_SECRET);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('redirects the overview page to /login when unauthenticated', () => {
+    const res = proxy(buildRequest('/', { ip: `10.0.11.${crypto.randomUUID().slice(0, 2)}` }));
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toContain('/login');
+  });
+
+  it('renders the login page itself without a session', () => {
+    const res = proxy(buildRequest('/login', { ip: `10.0.12.${crypto.randomUUID().slice(0, 2)}` }));
+    expect(res.status).not.toBe(307);
+  });
+
+  it('renders the overview page through when a valid session is present', () => {
+    const res = proxy(buildRequest('/', { cookie: sessionCookie(), ip: `10.0.13.${crypto.randomUUID().slice(0, 2)}` }));
+    expect(res.status).not.toBe(307);
+  });
+
+  it('does not redirect-loop pages when SESSION_SECRET itself is unconfigured', () => {
+    vi.stubEnv('SESSION_SECRET', '');
+    const res = proxy(buildRequest('/', { ip: `10.0.14.${crypto.randomUUID().slice(0, 2)}` }));
+    expect(res.status).not.toBe(307);
+  });
+});


### PR DESCRIPTION
**Stacks on #151 (RA-20)** — this issue's own proposed fix says to fold RA-20's body-size/rate-limit into the same `proxy.ts` file, so this PR is based on that branch rather than `main`. Review/merge #151 first, or merge both in that order — the diff below is RA-05-only.

## Summary
No route in the application had an authenticated caller: `/api/customers` and `/api/customers/[id]` dumped full customer PII (name, email, phone, segment, DND status) to anyone; `/api/metrics` exposed whole-book revenue figures; `/api/recovery/trigger` let any anonymous caller force outreach on every open journey; `/api/recovery/sweep` only checked its shared secret `if (configuredSecret)`, so it failed open whenever the env var was unset.

Per your choice, this adds **session-based dashboard login** (not a static API key) — a real login page, not just a header check.

## What's new
- `src/lib/auth/session.ts`: a stateless, signed session cookie — `base64url(payload) + HMAC-SHA256(payload, SESSION_SECRET)`, with a 12h expiry checked on every verification. No server-side session store.
- `src/lib/auth/crypto.ts`: `timingSafeStringEqual()`, reusing the same length-check-then-`crypto.timingSafeEqual` pattern already established in `src/lib/razorpay/webhooks.ts`.
- `/api/auth/login` and `/api/auth/logout`: login checks `DASHBOARD_USERNAME`/`DASHBOARD_PASSWORD` in constant time and sets an `httpOnly`, `sameSite=lax` cookie; both 503 if unconfigured, not silently accept-anything.
- `/login`: a real sign-in page.

## proxy.ts — three tiers, matcher broadened to pages too
- `/api/webhooks/*` and `/api/auth/*` exempt (webhook has its own HMAC check from RA-01; login/logout must be reachable unauthenticated).
- `/api/simulator/*` gated on `RECOVERAI_DEMO_MODE === 'true'` (404 otherwise), not a session — matches the existing convention from RA-02.
- `/api/recovery/*` accepts **either** a valid dashboard session **or** the `RECOVERY_SWEEP_SECRET`/`CRON_SECRET` cron secret via `timingSafeEqual`. I deviated from the issue's literal "cron secret required" wording here: the dashboard's own "Run AI Agent" (Navbar) and sweep (BatchControls) buttons call these routes directly from the browser, so cron-secret-only gating would have broken working UI functionality — which conflicts with the "dashboard still works end to end" acceptance criterion. An unconfigured secret with no session now returns 503, not the previous fail-open 200. Removed the now-redundant inline secret check from `sweep/route.ts` since `proxy.ts` gates it first.
- Every other `/api/*` route requires a valid session (401 otherwise).
- Page routes redirect to `/login` (307) when unauthenticated, except `/login` itself; if `SESSION_SECRET` is unset entirely, pages render instead of redirect-looping, so the misconfiguration is visible rather than trapping the operator.

## Test plan
- [x] New `tests/auth-session.test.ts`, `tests/auth-login-route.test.ts`, `tests/proxy-auth.test.ts`: token creation/verification (valid, wrong secret, tampered payload, expired, malformed), login route (503 unconfigured, 401 wrong creds with no cookie set, 200 with a verifiable httpOnly cookie, non-string payload handled), logout clears the cookie, and every proxy tier calling `proxy()` directly — session-required routes 401 without a cookie and pass with one, simulator 404s outside demo mode, recovery routes 503 unconfigured/401 wrong secret/pass with correct secret or session, webhook/auth routes exempt, pages redirect to `/login` and don't loop when unconfigured.
- [x] **Manually verified end-to-end against a running dev server**: unauthenticated page → 307 to `/login`; unauthenticated API → 401; wrong password → 401; correct login → verifiable session cookie; authenticated dashboard page and `/api/customers` → 200; demo-mode seeding works with no session; "Run AI Agent" trigger works via session with no cron secret configured; unauthenticated trigger with no secret configured → 503 (not 200); webhook route stays reachable (200) unauthenticated; logout immediately invalidates the session (subsequent API call 401s again).
- [x] `npm run typecheck` clean, `npm run lint` clean.
- [x] `npm test` — 84/84 passing, run 3x consecutively with no flakes.
- [x] Boundary-guardrail grep (`src/lib/recovery/`, `src/lib/ai/` vs `simulation`) — no violations.
- [x] `npm run build` — production build succeeds; route summary confirms `/login`, `/api/auth/login`, `/api/auth/logout`, and `ƒ Proxy (Middleware)` all register correctly.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)