### PR TITLE
fix: make PII controls real, then correct SECURITY.md and the ethics doc to match

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,17 +35,22 @@ RecoverAI adheres to the **OpenSSF (Open Source Security Foundation)** Best Prac
 - Length pre-checks ensure equal buffer allocation before executing `timingSafeEqual`, mitigating side-channel timing leaks.
 
 ### B. Idempotency & Replay Attack Defense
+- Event identity is read from the `x-razorpay-event-id` header — the field Razorpay actually sends the identifier in — not a body field that is never present, so deduplication genuinely matches repeat deliveries.
 - Every incoming webhook event ID and its SHA-256 payload digest are recorded in the `webhook_events` table.
-- Duplicate or replayed webhook events are intercepted and rejected with zero state corruption.
+- A duplicate delivery of an already-`processed` event is intercepted and rejected with zero state corruption.
+- Known gap tracked separately: a delivery that fails mid-processing is not yet automatically retried on redelivery (a fix that reclaims and reprocesses `failed` events is in review).
 
-### C. Zero-PII Data Minimization (DPDPA 2023)
-- No primary account numbers (PAN), CVVs, card expiration dates, or raw bank account credentials are ever stored in the database or sent to Google Gemini LLM prompts.
-- Phone numbers in audit logs and communication identifiers are masked or replaced with cryptographically secure random UUIDs.
+### C. PII Minimization (DPDPA 2023)
+- No primary account numbers (PAN), CVVs, card expiration dates, or raw bank account credentials are ever stored in the database or sent to Google Gemini LLM prompts. (`grep -rn "cardPan\|cvv" src` finds no read path from any request into storage or a prompt — only the demo card-detection helper in `tests/ethical-compliance.test.ts`, which exists to prove such data is never accepted.)
+- Customer names sent to Google Gemini prompts are truncated to first-name-only before the request is built (`src/lib/ai/messenger.ts`, `src/lib/ai/conversation.ts` — see `tests/llm-prompt-data-minimization.test.ts`). Full names, phone numbers, and email addresses are never included in a prompt.
+- Audit log entries (`writeAuditLog`, `src/lib/utils/audit.ts`) mask any `eventData` value that is itself a phone number or email address before it is persisted, via `maskPhone`/`maskEmail` in `src/lib/utils/pii.ts` (see `tests/pii-masking.test.ts`, `tests/audit-log-masking.test.ts`). This masks discrete phone/email fields, not phone/email substrings that might appear inside longer free-text fields such as a customer's own reply message or a dispatched message body — those are stored verbatim, since the audit trail's purpose is to reproduce exactly what was sent and received.
+- Communication tracking IDs (`recovery_actions.id`, `webhook_events.id`) are opaque, randomly generated identifiers, not derived from phone numbers or other PII.
 
 ### D. Architectural Boundary Separation
 - Static CI governance (`pr-governance.yml`) strictly forbids production recovery modules (`src/lib/recovery`, `src/lib/ai`) from importing testbed simulation models (`src/lib/simulation`), preventing test mocks from leaking into production logic.
 
 ### E. Automated Vulnerability Scanning
 - **Gitleaks**: Secrets and credential leak detection runs on every pull request.
-- **Dependency Audit**: `npm audit` scans all production dependencies for known CVEs.
+- **Dependency Audit**: `npm audit` runs on every pull request against the full dependency tree.
+  Known gap tracked separately: the workflow currently gates only on `critical`-severity findings and does not fail the build on a match (`continue-on-error: true`) — a tightened gate (`--audit-level=high --omit=dev`, gate enforced) is in review. Verified locally that this stricter check already passes against the current lockfile (0 vulnerabilities in production dependencies; 4 moderate dev-only findings via `drizzle-kit`'s `esbuild` dependency, not shipped to production).
 - **Static Analysis**: TypeScript strict mode and ESLint security rules run on every commit.

--- a/docs/ETHICAL_AI_FRAMEWORK.md
+++ b/docs/ETHICAL_AI_FRAMEWORK.md
@@ -17,7 +17,7 @@ graph TD
     B -->|Check 1| C["RBI Contact Hours: 8:00 AM - 7:00 PM IST"]
     B -->|Check 2| D["Anti-Harassment Ceiling: Max 3 Attempts Total"]
     B -->|Check 3| E["Sovereign Opt-Out: Instant STOP / Unsubscribe"]
-    B -->|Check 4| F["Zero-PII Isolation: Mask PAN / CVV / Phone"]
+    B -->|Check 4| F["PII Minimization: Never Accept PAN/CVV, Mask Phone/Email in Audit Logs"]
     
     C --> G["Compliant, Empathetic Multi-Lingual Outreach"]
     D --> G
@@ -26,23 +26,25 @@ graph TD
 ```
 
 ### 🛡️ Invariant 1: Mathematical Anti-Harassment Ceiling
-- **Hard Upper Bound**: Under no circumstances can any customer receive more than **3 outreach attempts** for a single failure.
-- **Progressive Exponential Backoff**: Outreach attempts are strictly spaced:
-  - **Attempt 1**: T + 0 (Immediate interactive notification on preferred channel)
-  - **Attempt 2**: T + 24 hours (SMS reminder with discount incentive if permitted)
-  - **Attempt 3**: T + 48 hours (Final conversational follow-up)
-- **Automatic Exhaustion**: After Attempt 3, the journey status permanently transitions to `exhausted`, preventing any automated agent or cron job from contacting the customer again.
+- **Hard Upper Bound**: `merchant_alert` allows a single attempt (nothing the customer can act on); every other strategy allows at most **3 outreach attempts** for a single failure (`src/lib/recovery/strategies.ts`, `STRATEGY_CONFIGS[*].maxAttempts`).
+- **Backoff, Per Strategy**: Retry timing is strategy-specific, enforced against each action's recorded `scheduledAt` before the next attempt is allowed to dispatch (`src/lib/recovery/coordinator.ts`, see `tests/retry-backoff-enforcement.test.ts`):
+  | Strategy | Attempt 1 | Attempt 2 (delay since Attempt 1) | Attempt 3 (delay since Attempt 2) |
+  | :--- | :--- | :--- | :--- |
+  | `payment_link` / `smart_retry` | T + 0 | + 1 hour | + 24 hours |
+  | `conversational` | T + 0 | + 2 hours | + 24 hours |
+  | `invoice_reminder` (B2B) | T + 0 | + 24 hours | + 168 hours |
+  | `merchant_alert` | T + 0 | — | — |
+- **Automatic Exhaustion**: After the strategy's final attempt, the journey status permanently transitions to `exhausted`, preventing any automated agent or cron job from contacting the customer again.
 
 ---
 
 ### 🛑 Invariant 2: Sovereign Customer Opt-Out (Right to be Forgotten)
-- **Universal Opt-Out Keywords**: RecoverAI detects explicit opt-outs across English, Hindi, and Hinglish:
-  - English: `STOP`, `UNSUBSCRIBE`, `CANCEL`, `QUIT`, `OPT OUT`
-  - Hindi / Hinglish: `band karo`, `mat bhejo`, `message mat karo`, `unsubscribe karo`
+- **Opt-Out Keywords**: The deterministic stopping-rule engine (`src/lib/recovery/stopping-rules.ts`) halts outreach and sets DND on `STOP`, `unsubscribe`, `band karo`, `mat bhejo` (see `tests/stopping-rules.test.ts`, `tests/ethical-compliance.test.ts`).
+  Known gap tracked separately: the conversational agent (`src/lib/ai/conversation.ts`) currently matches a *different*, broader keyword list (also `cancel`, `mat karo`) than the deterministic engine — the two can disagree on the same message. Both matchers are also substring-based today, so e.g. "the bank **stop**ped my transaction" incorrectly triggers opt-out. A fix unifying both into a single word-boundary matcher — covering English, Hindi, Hinglish, and Devanagari script, plus phrasings like "do not contact me again" that neither list currently catches — is in review.
 - **Instantaneous Halting**: When an opt-out intent is detected:
   1. Customer's `dnd_status` is updated to `opted_out` in the database.
   2. The recovery journey immediately transitions to `opted_out`.
-  3. All pending scheduled actions are purged.
+  3. No future action is ever created: `processRecoveryAttempt` checks the journey's status before dispatching and returns immediately for a terminal status (`opted_out`, `resolved`, `exhausted`). There is no queue of pre-scheduled rows to purge — the next attempt is only computed lazily when the coordinator is invoked again.
   4. An immutable audit record `customer_opted_out` is generated.
 - **Zero Dark Patterns**: Opt-out is immediate without confirmation loops or surveys.
 
@@ -50,9 +52,8 @@ graph TD
 
 ### ⏰ Invariant 3: RBI Fair Practices Code & Contact Hours Compliance
 - **Permitted Window**: Communications are strictly restricted to **8:00 AM to 7:00 PM IST** (`Asia/Kolkata` time zone).
-- **Graceful Night-Time Deferral**: If a payment fails at 11:30 PM:
-  - RecoverAI classifies the root cause and prepares the recovery link in the database.
-  - Outbound communication is deferred until **8:00 AM the following morning**.
+- **Graceful Night-Time Deferral**: If a payment fails at 11:30 PM, the coordinator classifies the root cause and prepares the recovery journey, but the contact-hours check (`checkContactHours: true`, enforced on every dispatch — see `tests/contact-hours-enforcement.test.ts`) refuses to send outreach until the window reopens at **8:00 AM**, and records a `stopping_rule_triggered` audit entry for the deferral rather than dropping it silently.
+  This deferral is invocation-driven, not a background scheduler: the deferred attempt actually dispatches the next time `processRecoveryAttempt` runs after 8:00 AM (via `/api/recovery/trigger` or `/api/recovery/sweep`), not automatically at the stroke of 8:00 AM — there is no cron job wired up in this codebase to invoke it on its own.
 - **No Nighttime Disruption**: Prevents intrusive WhatsApp notifications or SMS alerts while customers are sleeping.
 
 ---
@@ -63,7 +64,7 @@ graph TD
 | :--- | :--- |
 | **No Card PAN / CVV Storage** | Card PANs, CVVs, and banking PINs are never accepted or stored. All payment execution occurs exclusively on PCI-DSS certified Razorpay hosted pages. |
 | **LLM Data Minimization** | Prompts to Google Gemini receive only sanitized metadata: first name, amount in paise, error taxonomy reason, and payment link URL. Full phone numbers and email addresses are omitted. |
-| **Pseudonymized Identifiers** | Outreach message tracking IDs use cryptographically secure random UUIDs (`crypto.randomUUID()`) rather than phone number fragments. |
+| **Pseudonymized Identifiers** | Outreach message tracking IDs use cryptographically secure random identifiers (`nanoid`, `src/lib/utils/ids.ts`) rather than phone number fragments. |
 | **Transparent AI Identity** | Every message explicitly states the sender's identity and provides a direct, verifiable Razorpay link (`https://rzp.io/i/...`). |
 
 ---
@@ -71,7 +72,8 @@ graph TD
 ## 3. Human Escalation & Dispute Safeguards
 
 If a customer replies indicating a billing dispute (e.g., *"I was charged twice"*, *"I already paid this"*):
-1. RecoverAI's conversational intent parser classifies the message as `dispute`.
+1. RecoverAI's conversational intent parser classifies the message as `dispute` (`src/lib/ai/conversation.ts`).
 2. The agent responds empathetically acknowledging the discrepancy.
-3. The journey is flagged for merchant review without executing further automated payment retries.
-4. The immutable audit timeline displays the customer's exact dispute message for merchant auditability.
+3. The immutable audit timeline (`conversational_reply_sent`, `src/app/api/simulator/reply/route.ts`) records the classified intent and the customer's exact message for merchant auditability.
+
+**Not yet implemented**: a `dispute` classification does not currently change the journey's status or pause its retry schedule — outreach continues on the normal cadence exactly as it would for a `general_query`. Genuine automatic escalation (flagging the journey, halting further attempts pending merchant review) is future work, not a control this document should claim exists today.

--- a/src/lib/ai/conversation.ts
+++ b/src/lib/ai/conversation.ts
@@ -62,9 +62,11 @@ export async function processCustomerConversation(
   try {
     // customerName traces back to attacker-influenceable input (e.g. a webhook
     // payload's payment.notes.customer_name); contain it before it reaches the
-    // prompt (RA-03). customerMessage is left intact — it is the customer's own
+    // prompt (RA-03), and pass only the first name — the LLM prompt data
+    // minimization boundary documented in SECURITY.md/ETHICAL_AI_FRAMEWORK.md
+    // (RA-17). customerMessage is left intact — it is the customer's own
     // reply and the field this endpoint exists to interpret.
-    const safeCustomerName = sanitizePromptInput(input.customerName, 60);
+    const safeCustomerName = sanitizePromptInput(input.customerName, 60).split(' ')[0] || 'there';
     const userPrompt = `
 Customer "${safeCustomerName}" replied: "${input.customerMessage}"
 Amount: ${rupeeAmount}

--- a/src/lib/ai/messenger.ts
+++ b/src/lib/ai/messenger.ts
@@ -53,10 +53,13 @@ export async function generateRecoveryMessage(
 ): Promise<GeneratedMessageResult> {
   // The customer name traces back to attacker-influenceable input (e.g. a webhook
   // payload's payment.notes.customer_name). Strip newlines/control characters and
-  // cap length so it cannot be mistaken for prompt instructions (RA-03).
+  // cap length so it cannot be mistaken for prompt instructions (RA-03). Only the
+  // first name is kept — the full name is not data the LLM prompt needs, and
+  // SECURITY.md/ETHICAL_AI_FRAMEWORK.md both document first-name-only as the
+  // data minimization boundary for LLM prompts (RA-17).
   const params: MessageGenerationParams = {
     ...rawParams,
-    customerName: sanitizePromptInput(rawParams.customerName, 60),
+    customerName: sanitizePromptInput(rawParams.customerName, 60).split(' ')[0] || 'there',
   };
 
   const fallbackText = getTemplateFallbackMessage(params);

--- a/src/lib/recovery/strategies.ts
+++ b/src/lib/recovery/strategies.ts
@@ -47,7 +47,7 @@ export const STRATEGY_CONFIGS: Record<RecoveryStrategy, StrategyConfig> = {
     initialChannel: 'email',
     allowDiscount: false,
     maxDiscountPercentage: 0,
-    retryIntervalsHours: [24, 168, 336], // Day 1, Day 7, Day 14
+    retryIntervalsHours: [24, 168, 336], // each delay is relative to the previous attempt, not T+0: +24h, then +168h after that, then +336h after that
   },
   merchant_alert: {
     strategy: 'merchant_alert',

--- a/src/lib/utils/audit.ts
+++ b/src/lib/utils/audit.ts
@@ -2,6 +2,7 @@ import { db } from '../db';
 import { auditLogs } from '../db/schema';
 import { generateId } from './ids';
 import { getClock, formatIST } from './time';
+import { maskPiiDeep } from './pii';
 
 export type AuditActor = 'system' | 'agent' | 'customer' | 'razorpay';
 
@@ -27,7 +28,9 @@ export async function writeAuditLog(params: AuditLogParams): Promise<string> {
     actionId: params.actionId || null,
     actor: params.actor,
     eventType: params.eventType,
-    eventData: JSON.stringify(params.eventData),
+    // Phone/email values are masked before persisting (see RA-17); message
+    // content and other free text are stored as-is.
+    eventData: JSON.stringify(maskPiiDeep(params.eventData)),
     createdAt: nowStr,
   });
   

--- a/src/lib/utils/pii.ts
+++ b/src/lib/utils/pii.ts
@@ -1,0 +1,47 @@
+/**
+ * Masks a phone number, keeping only the country code and last 4 digits
+ * visible (e.g. "+919876543210" -> "+91******3210"). Values that don't
+ * match the expected shape are returned unchanged.
+ */
+export function maskPhone(phone: string): string {
+  return phone.replace(/^(\+\d{2})\d+(\d{4})$/, '$1******$2');
+}
+
+/**
+ * Masks an email address, keeping only the first character of the local
+ * part and the full domain (e.g. "aarav@example.com" -> "a***@example.com").
+ */
+export function maskEmail(email: string): string {
+  return email.replace(/^(.).*(@.*)$/, '$1***$2');
+}
+
+const PHONE_PATTERN = /^\+?\d[\d\s-]{7,14}\d$/;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function maskValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    if (EMAIL_PATTERN.test(value)) return maskEmail(value);
+    if (PHONE_PATTERN.test(value)) return maskPhone(value.replace(/[\s-]/g, ''));
+    return value;
+  }
+  if (Array.isArray(value)) return value.map(maskValue);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = maskValue(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Recursively walks an object and masks any string value that is, in its
+ * entirety, a phone number or email address, before it is persisted (see
+ * writeAuditLog / RA-17). This does not scan free-text fields for embedded
+ * phone/email substrings — only values that are themselves a phone number
+ * or email.
+ */
+export function maskPiiDeep<T>(value: T): T {
+  return maskValue(value) as T;
+}

--- a/tests/audit-log-masking.test.ts
+++ b/tests/audit-log-masking.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import crypto from 'crypto';
+import fs from 'fs';
+
+// Isolate this suite onto its own on-disk DB file so it never races the
+// shared DB used by tests/e2e-smoke.test.ts.
+const testDbPath = `./data/test-ra17-audit-${crypto.randomUUID()}.db`;
+process.env.DATABASE_URL = `file:${testDbPath}`;
+
+const { db } = await import('../src/lib/db');
+const schema = await import('../src/lib/db/schema');
+const { eq } = await import('drizzle-orm');
+const { generateId } = await import('../src/lib/utils/ids');
+const { getClock, formatIST } = await import('../src/lib/utils/time');
+const { writeAuditLog } = await import('../src/lib/utils/audit');
+
+describe('writeAuditLog masks phone/email in eventData before persisting (RA-17)', () => {
+  afterAll(() => {
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        fs.unlinkSync(testDbPath + suffix);
+      } catch {
+        // file may not exist
+      }
+    }
+  });
+
+  it('stores masked phone/email values, not raw ones', async () => {
+    const nowStr = formatIST(getClock().now());
+    const customerId = generateId('cust');
+    const failureId = generateId('fail');
+    const journeyId = generateId('rj');
+
+    await db.insert(schema.customers).values({
+      id: customerId,
+      name: 'Test Customer',
+      email: 'audit-mask@example.com',
+      phone: '+919800000000',
+      preferredLanguage: 'en',
+      segment: 'b2c',
+      totalFailures: 1,
+      totalRecoveredAmount: 0,
+      dndStatus: 'active',
+      createdAt: nowStr,
+      updatedAt: nowStr,
+    });
+    await db.insert(schema.paymentFailures).values({
+      id: failureId,
+      customerId,
+      razorpayPaymentId: 'pay_x',
+      razorpayOrderId: 'order_x',
+      amount: 10000,
+      currency: 'INR',
+      paymentMethod: 'card',
+      failureType: 'one_time',
+      errorCode: 'BAD_REQUEST_ERROR',
+      errorSource: 'customer',
+      errorStep: 'authorization',
+      errorReason: 'insufficient_funds',
+      errorDescription: 'Insufficient funds',
+      createdAt: nowStr,
+    });
+    await db.insert(schema.recoveryJourneys).values({
+      id: journeyId,
+      customerId,
+      failureId,
+      status: 'recovering',
+      strategy: 'payment_link',
+      amountAtRisk: 10000,
+      amountRecovered: 0,
+      maxAttempts: 3,
+      currentAttempt: 0,
+      createdAt: nowStr,
+      updatedAt: nowStr,
+    });
+
+    const logId = await writeAuditLog({
+      journeyId,
+      actor: 'system',
+      eventType: 'test_pii_event',
+      eventData: { phone: '+919800000000', email: 'audit-mask@example.com', reason: 'test' },
+    });
+
+    const [log] = await db.select().from(schema.auditLogs).where(eq(schema.auditLogs.id, logId));
+    const stored = JSON.parse(log.eventData);
+
+    expect(stored.phone).toBe('+91******0000');
+    expect(stored.email).toBe('a***@example.com');
+    expect(stored.reason).toBe('test');
+  });
+});

--- a/tests/llm-prompt-data-minimization.test.ts
+++ b/tests/llm-prompt-data-minimization.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * RA-17: SECURITY.md and ETHICAL_AI_FRAMEWORK.md both claim LLM prompts
+ * receive only the customer's first name, not the full name. Before this
+ * fix, generateRecoveryMessage/processCustomerConversation sanitized the
+ * name (RA-03) but still sent it in full. These tests inspect the actual
+ * prompt text sent to the mocked Gemini call to verify only the first name
+ * appears.
+ */
+const { mockGenerateContent } = vi.hoisted(() => ({ mockGenerateContent: vi.fn() }));
+
+vi.mock('@/lib/ai/gemini', () => ({
+  gemini: {
+    isAvailable: () => true,
+    getModel: () => ({ generateContent: mockGenerateContent }),
+  },
+}));
+
+import { generateRecoveryMessage } from '@/lib/ai/messenger';
+import { processCustomerConversation } from '@/lib/ai/conversation';
+
+const REAL_LINK = 'https://rzp.io/i/recov_rj_genuine123';
+
+function mockGeminiResponse(text: string) {
+  mockGenerateContent.mockResolvedValueOnce({ response: { text: () => text } });
+}
+
+function promptTextSentToGemini(): string {
+  const call = mockGenerateContent.mock.calls[0][0];
+  return call.contents[0].parts[0].text as string;
+}
+
+describe('LLM prompt data minimization — only first name is sent (RA-17)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('generateRecoveryMessage sends only the first name to Gemini', async () => {
+    mockGeminiResponse(
+      JSON.stringify({ message: `Hi Aarav, your ₹499 payment: ${REAL_LINK} Reply STOP to unsubscribe.` })
+    );
+
+    await generateRecoveryMessage({
+      customerName: 'Aarav Sharma Kapoor',
+      language: 'en',
+      channel: 'whatsapp',
+      amount: 49900,
+      failureReason: 'transaction decline',
+      paymentLinkUrl: REAL_LINK,
+    });
+
+    const prompt = promptTextSentToGemini();
+    expect(prompt).toContain('Aarav');
+    expect(prompt).not.toContain('Sharma');
+    expect(prompt).not.toContain('Kapoor');
+  });
+
+  it('processCustomerConversation sends only the first name to Gemini', async () => {
+    mockGeminiResponse(
+      JSON.stringify({
+        response_message: 'Thanks for reaching out.',
+        intent: 'general_query',
+        action_required: 'none',
+      })
+    );
+
+    await processCustomerConversation({
+      customerName: 'Priya Desai Nair',
+      customerMessage: 'when will this be resolved',
+      amount: 49900,
+      paymentLinkUrl: REAL_LINK,
+    });
+
+    const prompt = promptTextSentToGemini();
+    expect(prompt).toContain('Priya');
+    expect(prompt).not.toContain('Desai');
+    expect(prompt).not.toContain('Nair');
+  });
+});

--- a/tests/pii-masking.test.ts
+++ b/tests/pii-masking.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { maskPhone, maskEmail, maskPiiDeep } from '@/lib/utils/pii';
+
+describe('maskPhone', () => {
+  it('keeps the country code and last 4 digits, masks the rest', () => {
+    expect(maskPhone('+919876543210')).toBe('+91******3210');
+  });
+
+  it('returns non-matching input unchanged', () => {
+    expect(maskPhone('not-a-phone-number')).toBe('not-a-phone-number');
+  });
+});
+
+describe('maskEmail', () => {
+  it('keeps the first character and the domain, masks the rest of the local part', () => {
+    expect(maskEmail('aarav.sharma@example.com')).toBe('a***@example.com');
+  });
+
+  it('returns non-matching input unchanged', () => {
+    expect(maskEmail('not-an-email')).toBe('not-an-email');
+  });
+});
+
+describe('maskPiiDeep', () => {
+  it('masks a top-level phone field', () => {
+    const result = maskPiiDeep({ phone: '+919876543210', note: 'hello' });
+    expect(result.phone).toBe('+91******3210');
+    expect(result.note).toBe('hello');
+  });
+
+  it('masks a top-level email field', () => {
+    const result = maskPiiDeep({ email: 'aarav@example.com' });
+    expect(result.email).toBe('a***@example.com');
+  });
+
+  it('masks phone/email values nested inside arrays and objects', () => {
+    const result = maskPiiDeep({
+      customer: { contact: { phone: '+919876543210' }, tags: ['aarav@example.com', 'vip'] },
+    }) as { customer: { contact: { phone: string }; tags: string[] } };
+
+    expect(result.customer.contact.phone).toBe('+91******3210');
+    expect(result.customer.tags[0]).toBe('a***@example.com');
+    expect(result.customer.tags[1]).toBe('vip');
+  });
+
+  it('leaves free-text message content untouched (not an exact phone/email match)', () => {
+    const result = maskPiiDeep({ message: 'Hi Amit, your payment of ₹499 is pending.' });
+    expect(result.message).toBe('Hi Amit, your payment of ₹499 is pending.');
+  });
+});


### PR DESCRIPTION
## Summary
`SECURITY.md` §C claimed phone numbers are masked in audit logs and that no PII reaches Gemini prompts. Neither held: `writeAuditLog` stored `eventData` verbatim, and `generateRecoveryMessage`/`processCustomerConversation` sent the customer's **full** name (sanitized against injection by RA-03, but never truncated) to every prompt. `grep -rni "mask|redact" src` found nothing. `docs/ETHICAL_AI_FRAMEWORK.md`'s contact-hours/retry-schedule/opt-out claims had the same problem to varying degrees.

Per the issue's own philosophy — made the code true rather than weakening the document.

## Code fixes
- `src/lib/utils/pii.ts`: `maskPhone`/`maskEmail` (same shape as the issue's own proposed regexes), plus `maskPiiDeep()` which recursively masks any object value that is, in its entirety, a phone number or email — wired into `writeAuditLog` before `eventData` is persisted.
- `messenger.ts` and `conversation.ts` now truncate `customerName` to first-name-only before it reaches the Gemini prompt — the deterministic templates already did this (the issue's own evidence), the LLM path didn't.

## Docs: re-verified every claim, not just the ones in the issue's evidence block
- **§B**: event identity now correctly cites the `x-razorpay-event-id` header (RA-04, merged); added an honest note that failed-delivery retry reprocessing is a tracked gap.
- **§E**: noted the audit gate's `continue-on-error`/critical-only gap rather than claiming `npm audit` enforces anything today (verified: a tightened version already passes locally, PR in review).
- **Retry schedule**: replaced a single fictional "Attempt 2: T+24h, Attempt 3: T+48h" with the real, strategy-specific `STRATEGY_CONFIGS` intervals. Also fixed a wrong `// Day 1, Day 7, Day 14` comment in `strategies.ts` itself — the deltas are relative to the *previous* attempt, not T+0, so `invoice_reminder`'s real attempt 3 lands on day 8, not day 7.
- **Opt-out keywords**: corrected to what `stopping-rules.ts` actually matches today, with an honest note about its divergence from `conversation.ts`'s separate (broader, substring-based) list — a unifying fix is in review, not pretended to already exist.
- **Contact hours**: now describes the real invocation-driven behavior (no cron auto-fires at 8AM) instead of implying a scheduler.
- **Dispute handling**: removed the false "flagged for merchant review, retries halted" claim — intent is classified and audited, but nothing currently acts on it.
- Two smaller fixes: PAN/CVV framed as "masked" when they're never accepted at all; tracking IDs claimed `crypto.randomUUID()` when the code uses `nanoid`.

## Test plan
- [x] New `tests/pii-masking.test.ts`, `tests/audit-log-masking.test.ts` (isolated on-disk DB, real `writeAuditLog` call): `maskPhone`/`maskEmail` unit behavior, `maskPiiDeep` on nested objects/arrays and free text left untouched, and a real audit-log write proving stored `eventData` has masked phone/email values.
- [x] New `tests/llm-prompt-data-minimization.test.ts` (mocked Gemini): inspects the actual prompt text sent and confirms only the first name appears for both `generateRecoveryMessage` and `processCustomerConversation`.
- [x] `grep -rn "mask" src` now shows the real controls the document describes.
- [x] `npm run typecheck` clean, `npm run lint` clean.
- [x] `npm test` — 81/81 passing, run 3x consecutively with no flakes.
- [x] Boundary-guardrail grep (`src/lib/recovery/`, `src/lib/ai/` vs `simulation`) — no violations.
- [x] `npm run build` — production build succeeds.

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy & Security**
  * Audit records now mask phone numbers and email addresses, including nested data.
  * AI interactions use only the customer’s first name, reducing shared personal information.
  * Security documentation clarifies webhook tracking, data retention, dependency scanning, and PII handling.

* **Documentation**
  * Ethical AI guidance now details retry behavior, opt-out handling, nighttime deferrals, tracking IDs, and dispute responses.
  * Recovery retry timing guidance has been clarified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->