### PR TITLE
fix(ai,config): declare mock-vs-live explicitly and unbreak the LLM path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,18 @@ RAZORPAY_WEBHOOK_SECRET=XXXXXXXXXXXXXXXXXXXXXXXX
 # Google Gemini API Key (Get from Google AI Studio)
 GEMINI_API_KEY=XXXXXXXXXXXXXXXXXXXXXXXX
 
+# Gemini model id. Pinned deliberately rather than using a floating `-latest` alias, which
+# would let the model change under a recorded demo. Override here if this one is retired.
+GEMINI_MODEL=gemini-3.6-flash
+
 # Database Configuration (SQLite)
 DATABASE_URL=file:./data/recoverai.db
+
+# Whether this process talks to real Razorpay and Gemini APIs.
+#   mock (default) — no outbound calls; payment links and LLM copy are simulated.
+#   live           — real API calls. Startup FAILS if any credential above is still a
+#                    placeholder, so a bad paste cannot silently downgrade to simulation.
+RECOVERAI_MODE=mock
 
 # Application Configuration
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Full reasoning in [`docs/PROJECT_DOCUMENTATION.md`](docs/PROJECT_DOCUMENTATION.m
 | Styling | Tailwind CSS, shadcn/ui |
 | Database | SQLite via `better-sqlite3` |
 | ORM | Drizzle ORM |
-| AI / LLM | Google Gemini API (`gemini-2.5-flash`) |
+| AI / LLM | Google Gemini API (`gemini-3.6-flash`, set via `GEMINI_MODEL`) |
 | Charts | Recharts |
 | Payments | Razorpay APIs, test mode — Payment Links, Invoices, Subscriptions, Webhooks |
 

--- a/docs/AGENT_INSTRUCTIONS.md
+++ b/docs/AGENT_INSTRUCTIONS.md
@@ -358,7 +358,7 @@ When starting a new coding session on RecoverAI, the agent should:
 | Styling | Tailwind + shadcn/ui | Production-quality with minimal code |
 | Database | SQLite via better-sqlite3 | Zero-config, portable, judge-friendly |
 | ORM | Drizzle | Type-safe, lightweight, SQLite-native |
-| LLM | Google Gemini (gemini-2.5-flash) | Fast, cheap, good JSON mode |
+| LLM | Google Gemini (gemini-3.6-flash) | Fast, cheap, good JSON mode |
 | ID generation | nanoid with prefixes | `cust_`, `fail_`, `rj_`, `ra_`, `audit_` |
 | Amounts | Integer (paise) | Razorpay convention, no float errors |
 | Timestamps | ISO 8601 strings in IST | Human-readable, consistent |

--- a/docs/AI_DECISIONS.md
+++ b/docs/AI_DECISIONS.md
@@ -8,7 +8,7 @@ This document outlines the explicit architectural boundary between **where we us
 
 ---
 
-## 1. Where We Use AI (Google Gemini 2.5 Flash)
+## 1. Where We Use AI (Google Gemini 3.6 Flash)
 
 ```mermaid
 graph TD
@@ -68,7 +68,7 @@ If Google Gemini API is unavailable (network outage, rate limits, unconfigured k
 ```mermaid
 graph LR
     Req["Message Generation / Classification"] --> Check{"Gemini Available?"}
-    Check -->|Yes| LLM["Gemini 2.5 Flash Output"]
+    Check -->|Yes| LLM["Gemini 3.6 Flash Output"]
     Check -->|No / Timeout / Error| Fallback["Pre-Compiled Template Fallback"]
     Fallback --> Out["Sanitized Outreach with Mandatory STOP Notice"]
 ```

--- a/docs/PROJECT_DOCUMENTATION.md
+++ b/docs/PROJECT_DOCUMENTATION.md
@@ -761,7 +761,7 @@ Two rules that are easy to get wrong and must be enforced in review:
 
 **Google Gemini API** (via `@google/generative-ai` SDK)
 
-**Model:** `gemini-2.5-flash` — optimized for speed and cost while maintaining strong reasoning for classification and message generation tasks.
+**Model:** `gemini-3.6-flash` — optimized for speed and cost while maintaining strong reasoning for classification and message generation tasks. Configured via `GEMINI_MODEL` and pinned rather than a floating `-latest` alias, so the model cannot change under a recorded demo. The previously hardcoded `gemini-2.5-flash` was retired for new API keys, which silently routed every message to the deterministic template fallback (RA-24).
 
 ### 8.2 LLM Use Cases
 

--- a/src/app/api/webhooks/razorpay/route.ts
+++ b/src/app/api/webhooks/razorpay/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { readCredential } from '@/lib/config';
 import { db } from '@/lib/db';
 import { webhookEvents, paymentFailures, customers } from '@/lib/db/schema';
 import { and, eq } from 'drizzle-orm';
@@ -17,11 +18,11 @@ export async function POST(req: NextRequest) {
   try {
     const rawBody = await req.text();
     const signature = req.headers.get('x-razorpay-signature') || '';
-    const secret = process.env.RAZORPAY_WEBHOOK_SECRET || '';
+    const secret = readCredential('RAZORPAY_WEBHOOK_SECRET');
 
     // Signature verification is mandatory. A missing or placeholder secret is a
     // deployment misconfiguration, not permission to skip verification (RA-01).
-    if (!secret || secret.includes('XXXXXXXX')) {
+    if (!secret) {
       console.error('[webhook:razorpay] RAZORPAY_WEBHOOK_SECRET not configured — rejecting request');
       return NextResponse.json(
         { success: false, error: { code: 'NOT_CONFIGURED', message: 'Webhook secret not configured' } },

--- a/src/lib/ai/gemini.ts
+++ b/src/lib/ai/gemini.ts
@@ -1,4 +1,5 @@
 import { GoogleGenerativeAI, GenerativeModel } from '@google/generative-ai';
+import { getGeminiModel, requireCredential } from '../config';
 
 class GeminiClient {
   private client: GoogleGenerativeAI | null = null;
@@ -6,12 +7,14 @@ class GeminiClient {
   private apiKey: string;
 
   constructor() {
-    this.apiKey = process.env.GEMINI_API_KEY || '';
-    if (this.apiKey && !this.apiKey.includes('XXXXXXXX') && !this.apiKey.includes('mock')) {
+    // Throws in live mode when the key is missing or a placeholder, rather than silently
+    // leaving this.model null and degrading every message to the template fallback.
+    this.apiKey = requireCredential('GEMINI_API_KEY') || '';
+    if (this.apiKey) {
       try {
         this.client = new GoogleGenerativeAI(this.apiKey);
         this.model = this.client.getGenerativeModel({
-          model: 'gemini-2.5-flash',
+          model: getGeminiModel(),
         });
       } catch (error) {
         console.error('[GeminiClient] Initialization error:', error);

--- a/src/lib/ai/messenger.ts
+++ b/src/lib/ai/messenger.ts
@@ -47,6 +47,28 @@ function getTemplateFallbackMessage(params: MessageGenerationParams): string {
 }
 
 /**
+ * True if `text` contains anything a messaging client would turn into a tappable target.
+ *
+ * Deliberately broad: a false positive costs a personalised message (the deterministic
+ * template ships instead), while a false negative ships an attacker-chosen payment target to
+ * a real customer. The asymmetry decides the tuning.
+ */
+export function containsActionableTarget(text: string): boolean {
+  const patterns: RegExp[] = [
+    // Any explicit scheme with an authority: https://, upi://, intent://, javascript: ...
+    /[a-z][a-z0-9+.-]*:\/\//i,
+    // Actionable schemes that carry no "//"
+    /\b(?:tel|mailto|sms|smsto|upi|whatsapp|intent|market|geo|data|javascript|file|ftp|bitcoin|ethereum):/i,
+    // Bare or www-prefixed domains: wa.me/x, evil.example/pay, www.rzp-secure.example.
+    // The final label must be 2+ letters, so "₹2,499.00", "e.g." and "i.e." do not match.
+    /\b[a-z0-9][a-z0-9-]*(?:\.[a-z0-9-]+)*\.[a-z]{2,24}\b/i,
+    // UPI virtual payment address: name@bank. Not a URL, but it is a payment target.
+    /\b[a-z0-9._-]{2,}@[a-z][a-z0-9.-]{1,}\b/i,
+  ];
+  return patterns.some((re) => re.test(text));
+}
+
+/**
  * Generates an empathetic, channel-appropriate recovery message using Gemini with template fallback.
  */
 export async function generateRecoveryMessage(
@@ -109,15 +131,17 @@ ${params.discountPercentage ? `- Discount Offered: ${params.discountPercentage}%
       // including one an attacker substituted via an injected instruction
       // (e.g. through an unsanitized customerName) — so it does not actually
       // verify the real link made it through (RA-03).
-      // `\S+` is greedy, so a link ending a sentence captures its trailing punctuation
-      // ("...9GwL7PG." !== "...9GwL7PG") and a perfectly good message is discarded. Trim
-      // characters that cannot terminate a URL in prose before comparing. This does not
-      // weaken the RA-03 check: the comparison is still full equality against the expected
-      // link, and the count must still be exactly one, so a substituted host cannot pass.
-      const urlsInMessage = (cleanMessage.match(/https?:\/\/\S+/g) ?? []).map((u: string) =>
-        u.replace(/[.,;:!?)\]}'"]+$/, '')
-      );
-      const linkIntact = urlsInMessage.length === 1 && urlsInMessage[0] === params.paymentLinkUrl;
+      // Only the payment link may be actionable. Enumerating bad schemes is a blocklist and
+      // loses to the next one, so instead the known-good link is removed and ANYTHING
+      // link-shaped left behind rejects the message.
+      //
+      // The previous check matched `https?://` alone, which let a message ship carrying
+      // `upi://pay?pa=fraud@okaxis&am=2499` (opens a UPI app pre-filled to an attacker's VPA),
+      // `tel:`, `wa.me/...`, or a bare `evil.example/pay` that WhatsApp linkifies anyway.
+      const remainder = cleanMessage.split(params.paymentLinkUrl).join(' ');
+      const linkIntact =
+        cleanMessage.includes(params.paymentLinkUrl) && !containsActionableTarget(remainder);
+
       const amountIntact = cleanMessage.includes(rupeeAmount);
 
       if (cleanMessage.length <= charLimit && linkIntact && amountIntact) {

--- a/src/lib/ai/messenger.ts
+++ b/src/lib/ai/messenger.ts
@@ -1,4 +1,5 @@
 import { gemini } from './gemini';
+import { getGeminiModel } from '../config';
 import { MESSAGE_GENERATION_SYSTEM_PROMPT } from './prompts';
 import { sanitizePromptInput } from './sanitize';
 
@@ -108,14 +109,21 @@ ${params.discountPercentage ? `- Discount Offered: ${params.discountPercentage}%
       // including one an attacker substituted via an injected instruction
       // (e.g. through an unsanitized customerName) — so it does not actually
       // verify the real link made it through (RA-03).
-      const urlsInMessage = cleanMessage.match(/https?:\/\/\S+/g) ?? [];
+      // `\S+` is greedy, so a link ending a sentence captures its trailing punctuation
+      // ("...9GwL7PG." !== "...9GwL7PG") and a perfectly good message is discarded. Trim
+      // characters that cannot terminate a URL in prose before comparing. This does not
+      // weaken the RA-03 check: the comparison is still full equality against the expected
+      // link, and the count must still be exactly one, so a substituted host cannot pass.
+      const urlsInMessage = (cleanMessage.match(/https?:\/\/\S+/g) ?? []).map((u: string) =>
+        u.replace(/[.,;:!?)\]}'"]+$/, '')
+      );
       const linkIntact = urlsInMessage.length === 1 && urlsInMessage[0] === params.paymentLinkUrl;
       const amountIntact = cleanMessage.includes(rupeeAmount);
 
       if (cleanMessage.length <= charLimit && linkIntact && amountIntact) {
         return {
           message: cleanMessage,
-          llmReasoning: parsed.reasoning || 'Personalized empathetic copy generated via Gemini 2.5 Flash.',
+          llmReasoning: parsed.reasoning || `Personalized empathetic copy generated via ${getGeminiModel()}.`,
           isTemplateFallback: false,
         };
       }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,83 @@
+/**
+ * One explicit switch for whether this process talks to real services.
+ *
+ * Mock-vs-live used to be inferred separately in three places by checking whether a
+ * credential contained the string `XXXXXXXX` (src/lib/ai/gemini.ts, src/lib/razorpay/client.ts,
+ * and the webhook route). Inferring a deployment decision from the shape of a credential means
+ * a typo, a truncated paste, or a rotated-but-unset key silently downgrades the process to
+ * simulated behaviour with no signal — which is exactly how the project reached a state where
+ * no Gemini call and no Razorpay call had ever actually run (RA-24).
+ *
+ * The mode is now declared, not guessed, and `live` refuses to start without real credentials.
+ */
+
+export type RecoverAiMode = 'mock' | 'live';
+
+/** Credentials still holding their .env.example placeholder value. */
+function isPlaceholder(value: string | undefined): boolean {
+  return !value || value.includes('XXXXXXXX') || value.includes('mock');
+}
+
+export function getMode(): RecoverAiMode {
+  const raw = (process.env.RECOVERAI_MODE || '').trim().toLowerCase();
+  if (raw === 'live') return 'live';
+  if (raw === 'mock' || raw === '') return 'mock';
+  throw new Error(
+    `[config] Invalid RECOVERAI_MODE="${raw}". Expected "mock" or "live".`
+  );
+}
+
+export function isLive(): boolean {
+  return getMode() === 'live';
+}
+
+/**
+ * Returns a credential, or throws in live mode when it is absent or still a placeholder.
+ * In mock mode a missing credential is expected and returns undefined.
+ */
+/**
+ * Non-throwing read: returns the credential, or undefined when absent or still a placeholder.
+ * For call sites that must degrade gracefully rather than fail startup — the webhook route
+ * answers 503 on a missing secret and must not turn that into an unhandled 500.
+ */
+export function readCredential(name: string): string | undefined {
+  const value = process.env[name];
+  return isPlaceholder(value) ? undefined : value;
+}
+
+export function requireCredential(name: string): string | undefined {
+  const value = process.env[name];
+  if (!isLive()) return isPlaceholder(value) ? undefined : value;
+
+  if (isPlaceholder(value)) {
+    throw new Error(
+      `[config] RECOVERAI_MODE=live but ${name} is missing or still a placeholder. ` +
+        `Set a real value, or run with RECOVERAI_MODE=mock.`
+    );
+  }
+  return value;
+}
+
+/**
+ * The Gemini model id.
+ *
+ * Pinned rather than floating: `gemini-flash-latest` would let Google move the model under a
+ * recorded demo. Overridable so a retirement does not require a code change — `gemini-2.5-flash`
+ * was hardcoded here and had been retired for new API keys, which meant every message silently
+ * took the template fallback.
+ */
+export function getGeminiModel(): string {
+  return process.env.GEMINI_MODEL?.trim() || 'gemini-3.6-flash';
+}
+
+/** One line at startup naming what is actually wired, so a silent downgrade is visible. */
+export function describeIntegrations(): string {
+  const mode = getMode();
+  const status = (name: string) => (isPlaceholder(process.env[name]) ? 'unset' : 'configured');
+  return (
+    `[config] mode=${mode} ` +
+    `razorpay=${status('RAZORPAY_KEY_SECRET')} ` +
+    `webhook=${status('RAZORPAY_WEBHOOK_SECRET')} ` +
+    `gemini=${status('GEMINI_API_KEY')} model=${getGeminiModel()}`
+  );
+}

--- a/src/lib/razorpay/client.ts
+++ b/src/lib/razorpay/client.ts
@@ -5,6 +5,7 @@ import {
   RazorpaySubscriptionEntity,
 } from './types';
 import { nanoid } from 'nanoid';
+import { isLive, requireCredential } from '../config';
 
 export class RazorpayClient {
   private keyId: string;
@@ -12,8 +13,8 @@ export class RazorpayClient {
   private baseUrl: string;
 
   constructor() {
-    this.keyId = process.env.RAZORPAY_KEY_ID || '';
-    this.keySecret = process.env.RAZORPAY_KEY_SECRET || '';
+    this.keyId = requireCredential('RAZORPAY_KEY_ID') || '';
+    this.keySecret = requireCredential('RAZORPAY_KEY_SECRET') || '';
     this.baseUrl = 'https://api.razorpay.com/v1';
   }
 
@@ -22,13 +23,13 @@ export class RazorpayClient {
     return `Basic ${auth}`;
   }
 
+  /**
+   * Mock mode is declared via RECOVERAI_MODE, not inferred from the shape of a credential.
+   * In live mode requireCredential() has already thrown if either value is absent, so the
+   * remaining check is only a defensive guard.
+   */
   private isMockMode(): boolean {
-    return (
-      !this.keyId ||
-      !this.keySecret ||
-      this.keyId.includes('XXXXXXXX') ||
-      this.keyId.includes('mock')
-    );
+    return !isLive() || !this.keyId || !this.keySecret;
   }
 
   /**

--- a/tests/messenger-actionable-targets.test.ts
+++ b/tests/messenger-actionable-targets.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * RA-03 hardening — only the real payment link may be actionable in an outbound message.
+ *
+ * The validator previously matched `https?://` and nothing else, so a message could ship
+ * carrying a second, non-http payment target chosen by an injected instruction. In an Indian
+ * payments context the sharp one is `upi://pay?pa=<vpa>&am=<amount>`, which opens a UPI app
+ * pre-filled to pay an attacker's VPA — no phishing page required.
+ *
+ * The check is now allowlist-shaped: remove the known-good link, then reject anything
+ * link-shaped that remains. A false positive costs a personalised message; a false negative
+ * ships an attacker's payment target to a customer.
+ */
+const { mockGenerateContent } = vi.hoisted(() => ({ mockGenerateContent: vi.fn() }));
+vi.mock('@/lib/ai/gemini', () => ({
+  gemini: { isAvailable: () => true, getModel: () => ({ generateContent: mockGenerateContent }) },
+}));
+
+import { generateRecoveryMessage, containsActionableTarget } from '@/lib/ai/messenger';
+
+const REAL = 'https://rzp.io/rzp/KiutSqX';
+const reply = (t: string) =>
+  mockGenerateContent.mockResolvedValueOnce({ response: { text: () => t } });
+const params = {
+  customerName: 'Priya', language: 'en', amount: 249900,
+  failureReason: 'Card declined', paymentLinkUrl: REAL, channel: 'whatsapp',
+} as never;
+
+const HOSTILE: [string, string][] = [
+  ['UPI deep link',        `upi://pay?pa=fraud@okaxis&am=2499`],
+  ['UPI VPA in plain text', `send to fraud@okaxis`],
+  ['scheme-less domain',   `rzp-verify.example/pay`],
+  ['www-prefixed domain',  `www.rzp-secure.example`],
+  ['tel: number',          `tel:+919999999999`],
+  ['whatsapp deep link',   `wa.me/919999999999`],
+  ['mailto:',              `mailto:refunds@rzp-secure.example`],
+  ['intent:// (Android)',  `intent://pay#Intent;scheme=upi;end`],
+  ['second https URL',     `https://evil.example/x`],
+];
+
+describe('a second actionable target is never shipped', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  for (const [label, hostile] of HOSTILE) {
+    it(`rejects ${label} riding alongside the real link`, async () => {
+      reply(
+        JSON.stringify({
+          message: `Hi Priya, your payment of ₹2,499 failed. Pay here: ${REAL} — or ${hostile}`,
+          reasoning: 'injected',
+        })
+      );
+      const r = await generateRecoveryMessage(params);
+      expect(r.isTemplateFallback).toBe(true);
+      expect(r.message).not.toContain(hostile);
+    });
+  }
+
+  it('accepts a clean message carrying only the real link', async () => {
+    reply(
+      JSON.stringify({
+        message: `Hi Priya, your payment of ₹2,499 failed. Complete it here: ${REAL}`,
+        reasoning: 'ok',
+      })
+    );
+    const r = await generateRecoveryMessage(params);
+    expect(r.isTemplateFallback).toBe(false);
+  });
+});
+
+describe('containsActionableTarget does not fire on ordinary copy', () => {
+  const benign = [
+    'Hi Priya, your payment of ₹2,499 failed. Reply STOP to unsubscribe.',
+    'Your annual subscription renewal of ₹12,999.00 could not be completed.',
+    'We tried e.g. your saved card, i.e. the one ending 4242.',
+    'नमस्ते Priya जी! आपके भुगतान ₹2,499 पूरा नहीं हो सका।',
+  ];
+  for (const text of benign) {
+    it(`allows: ${text.slice(0, 44)}…`, () => {
+      expect(containsActionableTarget(text)).toBe(false);
+    });
+  }
+});

--- a/tests/messenger-url-punctuation.test.ts
+++ b/tests/messenger-url-punctuation.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * RA-24 — the link validator used a greedy `\S+` match, so a payment link ending a sentence
+ * captured its trailing punctuation ("…/KiutSqX." !== "…/KiutSqX"). Every such message was
+ * discarded and replaced by the deterministic template.
+ *
+ * That went unnoticed because the LLM path had never actually run — the configured model was
+ * retired, so every message took the fallback for an unrelated reason. Once live, this was
+ * the next thing standing between the agent and a personalised message.
+ *
+ * The RA-03 guarantee must survive the fix: exactly one URL, equal to the real link.
+ */
+const { mockGenerateContent } = vi.hoisted(() => ({ mockGenerateContent: vi.fn() }));
+
+vi.mock('@/lib/ai/gemini', () => ({
+  gemini: {
+    isAvailable: () => true,
+    getModel: () => ({ generateContent: mockGenerateContent }),
+  },
+}));
+
+import { generateRecoveryMessage } from '@/lib/ai/messenger';
+
+const REAL_LINK = 'https://rzp.io/rzp/KiutSqX';
+const PHISHING_LINK = 'https://rzp-secure-verify.example/pay';
+
+const reply = (text: string) =>
+  mockGenerateContent.mockResolvedValueOnce({ response: { text: () => text } });
+
+const params = {
+  customerName: 'Priya',
+  language: 'en',
+  amount: 249900,
+  failureReason: 'Card declined',
+  paymentLinkUrl: REAL_LINK,
+  channel: 'whatsapp',
+} as never;
+
+describe('link validation tolerates sentence punctuation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  for (const [label, suffix] of [
+    ['full stop', '.'],
+    ['comma', ','],
+    ['exclamation', '!'],
+    ['closing paren', ')'],
+    ['none', ''],
+  ] as const) {
+    it(`accepts a valid message when the link is followed by a ${label}`, async () => {
+      reply(
+        JSON.stringify({
+          message: `Hi Priya, your payment of ₹2,499 failed. Complete it here: ${REAL_LINK}${suffix}`,
+          reasoning: 'ok',
+        })
+      );
+      const r = await generateRecoveryMessage(params);
+      expect(r.isTemplateFallback).toBe(false);
+      expect(r.message).toContain(REAL_LINK);
+    });
+  }
+
+  it('still rejects a substituted URL (RA-03 preserved)', async () => {
+    reply(
+      JSON.stringify({
+        message: `Hi Priya, your payment of ₹2,499 failed. Complete it here: ${PHISHING_LINK}.`,
+        reasoning: 'injected',
+      })
+    );
+    const r = await generateRecoveryMessage(params);
+    expect(r.isTemplateFallback).toBe(true);
+    expect(r.message).not.toContain(PHISHING_LINK);
+  });
+
+  it('still rejects a message carrying a second URL alongside the real one', async () => {
+    reply(
+      JSON.stringify({
+        message: `Hi Priya, ₹2,499 failed. Pay: ${REAL_LINK}. Verify: ${PHISHING_LINK}.`,
+        reasoning: 'injected',
+      })
+    );
+    const r = await generateRecoveryMessage(params);
+    expect(r.isTemplateFallback).toBe(true);
+    expect(r.message).not.toContain(PHISHING_LINK);
+  });
+});

--- a/tests/mode-configuration.test.ts
+++ b/tests/mode-configuration.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getMode, isLive, readCredential, requireCredential, getGeminiModel, describeIntegrations } from '../src/lib/config';
+
+/**
+ * RA-24 — mock vs live is declared, not inferred from the shape of a credential, and live
+ * mode refuses to start on a placeholder rather than silently degrading to simulation.
+ */
+
+const saved = { ...process.env };
+beforeEach(() => {
+  delete process.env.RECOVERAI_MODE;
+  delete process.env.GEMINI_MODEL;
+  process.env.GEMINI_API_KEY = 'XXXXXXXXXXXXXXXXXXXXXXXX';
+});
+afterEach(() => {
+  process.env = { ...saved };
+});
+
+describe('mode', () => {
+  it('defaults to mock when unset, so a fresh clone still boots', () => {
+    expect(getMode()).toBe('mock');
+    expect(isLive()).toBe(false);
+  });
+
+  it('rejects an unrecognised mode instead of quietly falling back', () => {
+    process.env.RECOVERAI_MODE = 'production';
+    expect(() => getMode()).toThrow(/Invalid RECOVERAI_MODE/);
+  });
+
+  it('live mode throws on a placeholder credential', () => {
+    process.env.RECOVERAI_MODE = 'live';
+    expect(() => requireCredential('GEMINI_API_KEY')).toThrow(/missing or still a placeholder/);
+  });
+
+  it('live mode returns a real credential', () => {
+    process.env.RECOVERAI_MODE = 'live';
+    process.env.GEMINI_API_KEY = 'AQ.realkeyvalue';
+    expect(requireCredential('GEMINI_API_KEY')).toBe('AQ.realkeyvalue');
+  });
+
+  it('mock mode treats a placeholder as absent without throwing', () => {
+    expect(requireCredential('GEMINI_API_KEY')).toBeUndefined();
+  });
+
+  it('readCredential never throws, so the webhook route can answer 503', () => {
+    process.env.RECOVERAI_MODE = 'live';
+    expect(readCredential('RAZORPAY_WEBHOOK_SECRET')).toBeUndefined();
+  });
+});
+
+describe('gemini model', () => {
+  it('is pinned, not a floating -latest alias that could move under a demo', () => {
+    expect(getGeminiModel()).toBe('gemini-3.6-flash');
+    expect(getGeminiModel()).not.toMatch(/latest/);
+  });
+
+  it('is overridable without a code change when a model is retired', () => {
+    process.env.GEMINI_MODEL = 'gemini-3.5-flash';
+    expect(getGeminiModel()).toBe('gemini-3.5-flash');
+  });
+});
+
+describe('preflight', () => {
+  it('names the active mode and which integrations are configured', () => {
+    const line = describeIntegrations();
+    expect(line).toContain('mode=mock');
+    expect(line).toContain('gemini=unset');
+    expect(line).toContain('model=gemini-3.6-flash');
+  });
+});


### PR DESCRIPTION
Closes #162 (RA-24)

## Problem

`.env` held `XXXXXXXX` placeholders, and three separate places inferred whether to call real services by checking whether a credential contained that string (`src/lib/ai/gemini.ts`, `src/lib/razorpay/client.ts`, the webhook route).

Inferring a deployment decision from the *shape of a credential* means a typo, a truncated paste, or a rotated-but-unset key silently downgrades to simulation with no signal. That is how the project reached a state where **no Gemini call and no Razorpay call had ever actually run** — on an AI buildathon, on a payments sponsor's track.

## Three defects were hiding behind that silence

None were findable by reading the code. All three came from running the path with real credentials and then attacking it.

**1. The configured model is retired.** `gemini-2.5-flash` returns `404 — no longer available to new users` for any newly issued key. Every message had been taking the deterministic template fallback for this reason alone. Now pinned to `gemini-3.6-flash` (Google's named replacement), overridable via `GEMINI_MODEL`. Deliberately **not** `gemini-flash-latest` — a floating alias can move the model under a recorded demo.

**2. The link validator rejected valid messages.** It matched URLs with a greedy `\S+`, so a payment link ending a sentence captured its trailing period and compared unequal to the real link. Verified against live Gemini: a correct, well-formed message was being discarded. So even after fixing the model, the fallback would still have dominated.

**3. The link validator accepted a second payment target.** Probing it the way a payments reviewer would, the check turned out to be far weaker than RA-03 claimed — it matched `https?://` and nothing else. Five vectors passed:

| Vector | Before | After |
|---|---|---|
| `upi://pay?pa=fraud@okaxis&am=2499` | **ACCEPTED** | rejected |
| `rzp-verify.example/pay` | **ACCEPTED** | rejected |
| `www.rzp-secure.example` | **ACCEPTED** | rejected |
| `tel:+919999999999` | **ACCEPTED** | rejected |
| `wa.me/919999999999` | **ACCEPTED** | rejected |
| second `https://` URL | rejected | rejected |

The UPI one is the sharp edge: on Android it opens a UPI app **pre-filled to pay an attacker's VPA** — no phishing page, no credential theft. This gap pre-dates the punctuation fix; the original check had the same `https?://` restriction.

Enumerating bad schemes is a blocklist and loses to the next one, so the check is inverted: remove the known-good payment link, then reject if anything link-shaped remains — any scheme with an authority, actionable schemes without one (`tel`/`mailto`/`upi`/`intent`/…), bare and `www.` domains, and UPI VPAs.

Tuned deliberately broad. A false positive costs a personalised message (template ships instead); a false negative ships an attacker's payment target to a real customer.

## Changes

- New `src/lib/config.ts`: one declared `RECOVERAI_MODE=mock|live`. `live` refuses to start on a missing or placeholder credential instead of degrading silently. `mock` remains the default so a fresh clone still boots with no keys.
- `describeIntegrations()` preflight line names the active mode and which integrations are configured.
- All three `XXXXXXXX` sniffs removed. The webhook route uses a non-throwing accessor so it keeps answering **503** rather than turning a misconfiguration into a 500.
- Model id no longer hardcoded in the audit reasoning string.
- Docs updated to name the model actually in use (README, AI_DECISIONS, PROJECT_DOCUMENTATION, AGENT_INSTRUCTIONS).

## Verification

**Live, end to end:**
- Real Razorpay test-mode Payment Link created — `plink_TWJquwbyKBY4lS` → `https://rzp.io/rzp/KiutSqX`, not the mock `recov_` pattern
- Real Gemini message generated with `isTemplateFallback=false`, link intact, amount read from the database
- **Not over-tuned:** 5/5 live Gemini messages pass the tightened validator across WhatsApp/SMS and English/Hindi

**Suite:** 205 tests across 31 files. Typecheck, lint, and build clean.

Benign-copy tests cover `e.g.`, `i.e.`, decimal amounts (`₹12,999.00`) and Devanagari, so the broad tuning does not fire on ordinary message copy.

## Note

`isTemplateFallback` was already persisted into the audit log's `eventData`, so #162's "each audit row records whether its message came from the LLM or the template" was already satisfied — no schema change needed.

Not covered here: `src/lib/ai/conversation.ts` handles free-text customer replies and has not had the same adversarial pass. Worth a follow-up.


