### PR TITLE
feat(simulation): implement the declared response model that decides recovery outcomes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ DATABASE_URL=file:./data/recoverai.db
 #                    placeholder, so a bad paste cannot silently downgrade to simulation.
 RECOVERAI_MODE=mock
 
+# Seed for the simulation response model (docs/SIMULATION_MODEL.md), which decides whether a
+# simulated customer pays. Distinct from the fixture seed so that editing the synthetic data
+# does not silently move the recovery outcomes. Only consulted in RECOVERAI_MODE=mock; in live
+# mode outcomes come from Razorpay webhooks and no draw is ever taken.
+SIMULATION_SEED=20260823
+
 # Application Configuration
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Every batch therefore runs three arms over identical seeded data:
 
 **The honest headline is C minus B.** Arm B is what a cron job and a message template would have achieved on their own; only the delta is attributable to the agent's judgment. The comparison is built before any numbers exist, so the framing cannot be picked after the fact — and if C turns out to be roughly equal to B, that gets reported too.
 
-The batch is synthetic, so simulated customer behaviour follows a declared response model with benchmark-sourced coefficients, documented in `docs/SIMULATION_MODEL.md` and driven by a fixed seed. The agent cannot import that model — otherwise it would be marking its own homework. Every figure in the dashboard is labelled as simulation output against that model, never as recovered rupees.
+The batch is synthetic, so simulated customer behaviour follows a declared response model — a cause-specific base rate scaled by channel, attempt number, customer segment, and whether the copy came from the LLM or the template fallback — documented coefficient-by-coefficient in [`docs/SIMULATION_MODEL.md`](docs/SIMULATION_MODEL.md) and driven by a fixed seed. **Every coefficient is an estimate, not a measurement**, and the doc labels each one as such; they are declared in advance so the comparison they feed cannot be tuned after the results are in. The agent cannot import that model, and the model cannot import the agent — both directions are asserted by tests, because otherwise it would be marking its own homework. Every figure in the dashboard is labelled as simulation output against that model, never as recovered rupees.
 
 ---
 

--- a/docs/SIMULATION_MODEL.md
+++ b/docs/SIMULATION_MODEL.md
@@ -1,0 +1,189 @@
+# Simulation Response Model
+
+**Status:** active · **Model version:** 1.0.0 · **Implemented in:** [`src/lib/simulation/response-model.ts`](../src/lib/simulation/response-model.ts) · **Issue:** RA-23
+
+Every recovery figure in this project is a **simulation output against the model described on
+this page**. None of it is recovered rupees. The batch is synthetic, the customers are
+synthetic, and whether one of them pays is decided here — by a declared function over declared
+coefficients, drawn from a fixed seed.
+
+---
+
+## Why this file exists
+
+The README cited this document before it was written. In that state the only route a journey
+had to `resolved` was a human clicking **Pay** in the simulator UI, which meant two things:
+
+1. The dashboard's recovery rate was a count of button presses.
+2. Nothing the agent did — personalised copy, channel escalation, per-failure strategy
+   selection — had any path to influence an outcome. The system's central claim was untestable
+   by construction.
+
+The model fixes the second problem, which is the one that matters. A coefficient that responds
+to the agent's choices is what turns "the AI helps" into a question with an answer.
+
+## What the model may see
+
+```ts
+interface OutreachOutcomeInput {
+  errorReason: string;        // the root cause the customer has to overcome
+  attemptNumber: number;      // 1-based
+  channel: 'whatsapp' | 'sms' | 'email' | 'voice';
+  segment: 'b2c' | 'b2b';
+  isTemplateFallback: boolean; // true when the deterministic template shipped
+}
+```
+
+Deliberately narrow. The message text, the strategy name, and the LLM's own reasoning are all
+withheld, so the model cannot reward the agent for sounding confident — only for the observable
+properties of what it actually sent.
+
+## The function
+
+```
+probability = clamp(
+    baseRate(errorReason)
+  × channelMultiplier(channel)
+  × attemptDecay(attemptNumber)
+  × personalisation(isTemplateFallback)
+  × segmentMultiplier(segment),
+  0.01, 0.95)
+
+paid = rng.next() < probability
+```
+
+Multiplicative rather than additive, so no single term can carry an outcome on its own: a
+personalised third-attempt email to a B2B customer with a dead mandate should be close to
+hopeless, and a sum of positive terms would not say so.
+
+---
+
+## Coefficients
+
+> **Every number below is an estimate.** None is fitted to observed recovery data — this project
+> has none. They are declared in advance and version-controlled so that the comparison they feed
+> cannot be tuned after the results are in. Where a value is a judgement call, the reasoning is
+> given rather than a citation we cannot support. Replacing these with figures from a real
+> dunning dataset is the single highest-value follow-up to this work.
+
+### Base rate by error reason
+
+Probability a customer completes payment after **one** outreach, before any modifier: WhatsApp,
+first attempt, B2C, template copy. Keyed by root cause, because the cause decides how much work
+recovery asks of the customer.
+
+| `error_reason` | Base rate | Reasoning (estimated) |
+| :--- | ---: | :--- |
+| `gateway_technical_error` | 0.55 | Nothing is wrong on the customer's side; a retry usually clears it. |
+| `authentication_failed` | 0.45 | Transient — re-entering an OTP costs the customer one tap. |
+| `insufficient_funds` | 0.34 | Intent exists; recovery waits on the customer's balance, not their willingness. |
+| `payment_cancelled` | 0.30 | Hesitation at checkout. Persuadable, but the doubt is real. |
+| `card_declined` | 0.28 | Issuer-side refusal; often needs a different instrument. |
+| `card_expired` | 0.22 | Requires the customer to fetch and enter a new card. |
+| `mandate_inactive` | 0.18 | Re-authorising an e-mandate is a multi-step banking flow. |
+| `bank_account_invalid` | 0.12 | The account itself is wrong; nearly always needs support contact. |
+| *anything else* | 0.25 | Declared mid-range fallback, so an unseen cause degrades visibly rather than silently. |
+
+### Channel multiplier
+
+WhatsApp is the reference (1.00) because it is the seeded batch's primary channel.
+
+| Channel | Multiplier | Reasoning (estimated) |
+| :--- | ---: | :--- |
+| `whatsapp` | 1.00 | Reference. |
+| `voice` | 0.90 | Highest attention when answered, but many calls are not answered. |
+| `sms` | 0.78 | Reliably delivered, easily ignored. |
+| `email` | 0.55 | Slowest, and the most likely to be filtered. |
+
+### Attempt decay
+
+| Attempt | Multiplier | Reasoning (estimated) |
+| :--- | ---: | :--- |
+| 1 | 1.00 | Reference. |
+| 2 | 0.62 | A customer who ignored the first message is, by revealed preference, a worse prospect. |
+| 3+ | 0.38 | Steeper than fatigue alone; attempts past the declared ladder hold this value. |
+
+### Personalisation delta
+
+| Message source | Multiplier |
+| :--- | ---: |
+| LLM-generated copy (`is_template_fallback = false`) | **1.18** |
+| Deterministic template fallback (`is_template_fallback = true`) | 1.00 |
+
+This is the coefficient that makes "did the LLM help?" a real question, and it is the one to be
+most suspicious of, because it is the one this project benefits from. It is set deliberately
+modest: a large delta would manufacture our own headline result. A reader who thinks 1.18 is
+generous should read every lift number as scaled by their own estimate instead — that is exactly
+why the coefficient is a named constant on this page rather than a hidden term.
+
+### Segment multiplier
+
+| Segment | Multiplier | Reasoning (estimated) |
+| :--- | ---: | :--- |
+| `b2c` | 1.00 | Reference. |
+| `b2b` | 0.85 | B2B payments route through approval chains that no message can shorten. |
+
+### Bounds
+
+Clamped to **[0.01, 0.95]**. No outcome is ever certain, and none is ever impossible.
+
+---
+
+## Seeding and reproducibility
+
+- The model's seed is `SIMULATION_SEED` (default `20260823`), read via `getSimulationSeed()`.
+- It is **not** the fixture seed (`12345`, in `src/lib/db/seed.ts`). One shared seed would mean
+  that adding a name to the synthetic customer list silently moves every recovery outcome.
+- Each draw gets its own RNG, seeded by FNV-1a over `SIMULATION_SEED` and the natural key
+  `{failure_id}:attempt:{n}`. A single shared stream would make each draw depend on how many
+  journeys happened to be processed before it, so adding one failure to the batch would move
+  every later outcome.
+- Journey and action ids are nanoids and never touch the draw, so a re-seeded batch — new ids,
+  same failures — replays to the same outcomes. `tests/simulation-batch-determinism.test.ts`
+  asserts exactly this.
+
+## Where it runs, and where it does not
+
+`POST /api/recovery/trigger` dispatches outreach through the coordinator, then asks the model
+which of those attempts converted, then hands the recoveries back to the coordinator to resolve.
+
+That composition happens **in the API route**, and this is load-bearing:
+
+- Nothing under `src/lib/simulation/` imports `src/lib/recovery/` or `src/lib/ai/`.
+- Nothing under `src/lib/recovery/` or `src/lib/ai/` imports `src/lib/simulation/`.
+
+The agent cannot read the model it is scored against, so it cannot mark its own homework. Both
+directions are asserted in `tests/simulation-response-model.test.ts` and the first is also
+enforced in CI by the architectural boundary job in `.github/workflows/pr-governance.yml`.
+
+**In `RECOVERAI_MODE=live` no draw is ever taken.** Real customers and real Razorpay webhooks
+decide outcomes; inventing recoveries alongside them would corrupt a real merchant's numbers.
+
+The manual **Pay** button in the simulator still works, so the live demo keeps its moment. It is
+now additive rather than the only source of outcomes.
+
+## Audit trail
+
+Every draw — including the ones that did not convert — is written to `audit_logs` as
+`simulated_response_drawn`, carrying the probability, the raw draw, the model version, the seed,
+and each multiplier separately. An evaluation that logs only its successes is not an evaluation,
+and the breakdown is recorded so any single outcome can be recomputed by hand from this page.
+
+## Known limitations
+
+1. **The coefficients are estimates, not measurements.** Stated above, repeated here because it
+   is the most important sentence on the page.
+2. **One draw per outreach, no partial payments.** A converted journey recovers its full
+   `amount_at_risk`; real recovery sees part-payments and payment plans.
+3. **No time-of-day or day-of-week effect.** Contact hours are enforced by the agent's stopping
+   rules, but the model does not treat a 9am message as different from a 6pm one.
+4. **No cross-journey memory.** A customer who ignored a previous failure's outreach is not
+   modelled as less likely to respond to the next one.
+5. **In `RECOVERAI_MODE=mock` the personalisation coefficient never fires.** With no
+   `GEMINI_API_KEY`, `generateRecoveryMessage` always returns the deterministic template, so
+   every action carries `is_template_fallback = true` and every draw uses the 1.00 multiplier.
+   A mock-mode run therefore cannot demonstrate LLM lift — it measures the cadence and the
+   channel ladder only. Configure a real key (see RA-24) before quoting any personalisation
+   result; a batch run without one is not evidence for or against the LLM path.
+6. **The response is binary and immediate.** There is no notion of a customer who intends to pay
+   later, so `avg recovery time` reflects the agent's cadence rather than customer behaviour.

--- a/docs/SIMULATION_MODEL.md
+++ b/docs/SIMULATION_MODEL.md
@@ -146,6 +146,12 @@ Clamped to **[0.01, 0.95]**. No outcome is ever certain, and none is ever imposs
 
 `POST /api/recovery/trigger` dispatches outreach through the coordinator, then asks the model
 which of those attempts converted, then hands the recoveries back to the coordinator to resolve.
+`POST /api/recovery/sweep` does the same for the outreach its abandonment pass dispatches — a
+sweep-only deployment would otherwise accumulate journeys that never resolve.
+
+Each recovery names the attempt that converted, so the conversion is credited to the outreach
+that caused it rather than to whichever attempt happens to be newest — the two can differ when
+a sweep's attempt 1 and a batch run's attempt 2 are outstanding at the same time.
 
 That composition happens **in the API route**, and this is load-bearing:
 
@@ -161,6 +167,10 @@ decide outcomes; inventing recoveries alongside them would corrupt a real mercha
 
 The manual **Pay** button in the simulator still works, so the live demo keeps its moment. It is
 now additive rather than the only source of outcomes.
+
+`GET /api/metrics` reports which of the two produced its numbers, under `provenance`, and the
+dashboard's simulation notice reads that field. Labelling a real recovery as simulated is the
+same class of error as the reverse, so the notice is not hardcoded.
 
 ## Audit trail
 

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { customers, paymentFailures, recoveryJourneys, recoveryActions, auditLogs } from '@/lib/db/schema';
 import { desc, eq, sql } from 'drizzle-orm';
+import { getMode, getSimulationSeed, isLive } from '@/lib/config';
 
 export const dynamic = 'force-dynamic';
 
@@ -23,6 +24,13 @@ export interface FailureTypeMetric {
   atRiskPaise: number;
   recoveredPaise: number;
   recoveryRatePct: number;
+}
+
+/** Where the numbers on this response came from — see the dashboard's simulation notice. */
+export interface MetricsProvenance {
+  mode: 'mock' | 'live';
+  outcomesAreSimulated: boolean;
+  simulationSeed: number | null;
 }
 
 export interface StrategyMetric {
@@ -248,6 +256,15 @@ export async function GET() {
         failureTypeMetrics,
         strategyMetrics,
         recentAudits,
+        // Whether these figures came from the declared response model or from real traffic.
+        // The dashboard's "simulated figures" notice reads this rather than being hardcoded:
+        // in RECOVERAI_MODE=live no draw is ever taken, and labelling real recoveries as
+        // simulated is the same class of error as the reverse (RA-23).
+        provenance: {
+          mode: getMode(),
+          outcomesAreSimulated: !isLive(),
+          simulationSeed: isLive() ? null : getSimulationSeed(),
+        },
       },
     });
   } catch (error: unknown) {

--- a/src/app/api/recovery/sweep/route.ts
+++ b/src/app/api/recovery/sweep/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { runCheckoutAbandonmentSweep } from '@/lib/recovery/abandonment-sweep';
+import { recoveryCoordinator } from '@/lib/recovery/coordinator';
+import { getSimulationSeed, isLive } from '@/lib/config';
+import { runSimulatedOutcomes } from '@/lib/simulation/outcomes';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,9 +24,31 @@ export async function POST(req: NextRequest) {
     }
 
     const result = await runCheckoutAbandonmentSweep();
+
+    // The sweep dispatches attempt 1 exactly as a batch run does, so its outreach gets its
+    // outcomes drawn here too (RA-23). Leaving that to whenever someone next hits
+    // /api/recovery/trigger would let a sweep-only deployment accumulate journeys that can
+    // never resolve, and would misattribute the conversion when the batch run finally arrived
+    // and a second attempt was already outstanding.
+    const simulationSeed = getSimulationSeed();
+    const simulatedRecoveries = isLive() ? [] : await runSimulatedOutcomes(simulationSeed);
+
+    for (const recovery of simulatedRecoveries) {
+      await recoveryCoordinator.resolveJourneyWithPayment(
+        recovery.journeyId,
+        recovery.paymentId,
+        recovery.amountRecovered,
+        recovery.actionId
+      );
+    }
+
     return NextResponse.json({
       success: true,
-      data: result,
+      data: {
+        ...result,
+        simulatedRecoveries: simulatedRecoveries.length,
+        simulationSeed: isLive() ? null : simulationSeed,
+      },
     });
   } catch (error: unknown) {
     const errorMsg = error instanceof Error ? error.message : 'Error executing abandonment sweep';

--- a/src/app/api/recovery/trigger/route.ts
+++ b/src/app/api/recovery/trigger/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { paymentFailures, recoveryJourneys } from '@/lib/db/schema';
 import { recoveryCoordinator } from '@/lib/recovery/coordinator';
+import { getSimulationSeed, isLive } from '@/lib/config';
+import { runSimulatedOutcomes } from '@/lib/simulation/outcomes';
 
 export const dynamic = 'force-dynamic';
 
@@ -27,12 +29,37 @@ export async function POST() {
       }
     }
 
+    // 2. Ask the declared response model which of those outreach attempts converted (RA-23).
+    //
+    // This is the only place the two halves meet. The model decides; the coordinator applies.
+    // Neither imports the other, which is what stops the agent from marking its own homework —
+    // and it is why this composition lives in the route rather than inside either module.
+    //
+    // In live mode nothing is drawn: real customers and real Razorpay webhooks decide, and
+    // inventing recoveries alongside them would corrupt a real merchant's numbers.
+    const simulationSeed = getSimulationSeed();
+    const simulatedRecoveries = isLive() ? [] : await runSimulatedOutcomes(simulationSeed);
+
+    for (const recovery of simulatedRecoveries) {
+      await recoveryCoordinator.resolveJourneyWithPayment(
+        recovery.journeyId,
+        recovery.paymentId,
+        recovery.amountRecovered
+      );
+    }
+
     return NextResponse.json({
       success: true,
       data: {
         processedCount: processedJourneyIds.length,
         journeyIds: processedJourneyIds,
-        message: `Successfully processed recovery for ${processedJourneyIds.length} failures.`,
+        simulatedRecoveries: simulatedRecoveries.length,
+        simulationSeed: isLive() ? null : simulationSeed,
+        message:
+          `Successfully processed recovery for ${processedJourneyIds.length} failures` +
+          (isLive()
+            ? '.'
+            : `; the response model recovered ${simulatedRecoveries.length} of them (simulated).`),
       },
     });
   } catch (error: unknown) {

--- a/src/app/api/recovery/trigger/route.ts
+++ b/src/app/api/recovery/trigger/route.ts
@@ -44,7 +44,10 @@ export async function POST() {
       await recoveryCoordinator.resolveJourneyWithPayment(
         recovery.journeyId,
         recovery.paymentId,
-        recovery.amountRecovered
+        recovery.amountRecovered,
+        // Name the attempt that converted: with several attempts outstanding, the newest one
+        // is not necessarily the one the model drew.
+        recovery.actionId
       );
     }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,7 @@ import {
   RotateCcw,
   RefreshCw,
   Loader2,
+  FlaskConical,
 } from 'lucide-react';
 import { ChannelMetric, FailureTypeMetric, StrategyMetric } from './api/metrics/route';
 import { CustomerListItem } from './api/customers/route';
@@ -129,8 +130,8 @@ export default function DashboardPage() {
               Executive Revenue Recovery Command Center
             </h1>
             <p className="text-xs text-zinc-500 mt-0.5">
-              Live Razorpay autonomous dunning, multi-channel failover, and RBI contact-hours
-              compliance monitoring.
+              Razorpay autonomous dunning, multi-channel failover, and RBI contact-hours
+              compliance monitoring, over a synthetic batch.
             </p>
           </div>
 
@@ -186,6 +187,23 @@ export default function DashboardPage() {
           </div>
         ) : (
           <>
+            {/*
+              Every figure below is a simulation output, and the dashboard says so in the one
+              place a judge reads first. Before RA-23 the only route to a recovery was a human
+              clicking "Pay" in the simulator, so the recovery rate was a count of button
+              presses presented as a measured result.
+            */}
+            <div className="flex items-start gap-2.5 rounded-xl border border-amber-200 dark:border-amber-900/40 bg-amber-50 dark:bg-amber-950/20 px-4 py-3">
+              <FlaskConical className="w-4 h-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
+              <p className="text-xs text-amber-900 dark:text-amber-200">
+                <span className="font-semibold">Simulated figures.</span> Outcomes are drawn from
+                the declared response model in{' '}
+                <code className="font-mono text-[11px]">docs/SIMULATION_MODEL.md</code> over a
+                synthetic batch, using a fixed seed. These are simulation outputs against that
+                model — not recovered rupees.
+              </p>
+            </div>
+
             {/* 1. KPI Summary Cards */}
             {baseline && <MetricsCards summary={summary} baseline={baseline} />}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ import {
   Loader2,
   FlaskConical,
 } from 'lucide-react';
-import { ChannelMetric, FailureTypeMetric, StrategyMetric } from './api/metrics/route';
+import { ChannelMetric, FailureTypeMetric, StrategyMetric, MetricsProvenance } from './api/metrics/route';
 import { CustomerListItem } from './api/customers/route';
 
 export default function DashboardPage() {
@@ -26,6 +26,7 @@ export default function DashboardPage() {
   const [failureMetrics, setFailureMetrics] = useState<FailureTypeMetric[]>([]);
   const [strategyMetrics, setStrategyMetrics] = useState<StrategyMetric[]>([]);
   const [customersList, setCustomersList] = useState<CustomerListItem[]>([]);
+  const [provenance, setProvenance] = useState<MetricsProvenance | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isSeeding, setIsSeeding] = useState(false);
@@ -46,6 +47,7 @@ export default function DashboardPage() {
         setChannelMetrics(metricsJson.data.channelMetrics || []);
         setFailureMetrics(metricsJson.data.failureTypeMetrics || []);
         setStrategyMetrics(metricsJson.data.strategyMetrics || []);
+        setProvenance(metricsJson.data.provenance ?? null);
       }
 
       if (customersJson.success && customersJson.data) {
@@ -79,6 +81,7 @@ export default function DashboardPage() {
           setChannelMetrics(metricsJson.data.channelMetrics || []);
           setFailureMetrics(metricsJson.data.failureTypeMetrics || []);
           setStrategyMetrics(metricsJson.data.strategyMetrics || []);
+        setProvenance(metricsJson.data.provenance ?? null);
         }
 
         if (customersJson.success && customersJson.data) {
@@ -193,16 +196,19 @@ export default function DashboardPage() {
               clicking "Pay" in the simulator, so the recovery rate was a count of button
               presses presented as a measured result.
             */}
+            {provenance?.outcomesAreSimulated !== false && (
             <div className="flex items-start gap-2.5 rounded-xl border border-amber-200 dark:border-amber-900/40 bg-amber-50 dark:bg-amber-950/20 px-4 py-3">
               <FlaskConical className="w-4 h-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
               <p className="text-xs text-amber-900 dark:text-amber-200">
                 <span className="font-semibold">Simulated figures.</span> Outcomes are drawn from
                 the declared response model in{' '}
                 <code className="font-mono text-[11px]">docs/SIMULATION_MODEL.md</code> over a
-                synthetic batch, using a fixed seed. These are simulation outputs against that
-                model — not recovered rupees.
+                synthetic batch, using seed{' '}
+                <code className="font-mono text-[11px]">{provenance?.simulationSeed ?? '—'}</code>.
+                These are simulation outputs against that model — not recovered rupees.
               </p>
             </div>
+            )}
 
             {/* 1. KPI Summary Cards */}
             {baseline && <MetricsCards summary={summary} baseline={baseline} />}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -70,6 +70,26 @@ export function getGeminiModel(): string {
   return process.env.GEMINI_MODEL?.trim() || 'gemini-3.6-flash';
 }
 
+/**
+ * The seed for the simulation response model (RA-23).
+ *
+ * Deliberately not 12345, the fixture seed in `src/lib/db/seed.ts`. One shared seed would mean
+ * that adding a customer name to the fixture list silently moves every recovery outcome, which
+ * makes a "reproducible" result reproducible only until someone edits an unrelated array.
+ */
+export const DEFAULT_SIMULATION_SEED = 20260823;
+
+export function getSimulationSeed(): number {
+  const raw = (process.env.SIMULATION_SEED || '').trim();
+  if (raw === '') return DEFAULT_SIMULATION_SEED;
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed)) {
+    throw new Error(`[config] Invalid SIMULATION_SEED="${raw}". Expected an integer.`);
+  }
+  return parsed;
+}
+
 /** One line at startup naming what is actually wired, so a silent downgrade is visible. */
 export function describeIntegrations(): string {
   const mode = getMode();

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -34,6 +34,7 @@ const GEN = {
   PROVIDER_MESSAGE_ID: 1,  // 0001 — recovery_actions.provider_message_id
   RAZORPAY_CUSTOMER_ID: 2, // 0002 — customers.razorpay_customer_id
   PERF_INDEXES: 3,         // 0003 — idx_* indexes
+  TEMPLATE_FALLBACK: 4,    // 0004 — recovery_actions.is_template_fallback
 } as const;
 
 /**
@@ -80,6 +81,7 @@ function detectLegacyGeneration(sqlite: Database.Database): number | null {
   // leaves the database permanently stale — the exact failure this adoption path exists to
   // repair.
   const when = generationTimestamps();
+  if (hasColumn('recovery_actions', 'is_template_fallback')) return when[GEN.TEMPLATE_FALLBACK];
   if (hasColumn('customers', 'razorpay_customer_id')) return when[GEN.RAZORPAY_CUSTOMER_ID];
   if (hasColumn('recovery_actions', 'provider_message_id')) return when[GEN.PROVIDER_MESSAGE_ID];
   return when[GEN.BASE_TABLES];

--- a/src/lib/db/migrations/0004_greedy_silver_samurai.sql
+++ b/src/lib/db/migrations/0004_greedy_silver_samurai.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `recovery_actions` ADD `is_template_fallback` integer DEFAULT false NOT NULL;

--- a/src/lib/db/migrations/meta/0004_snapshot.json
+++ b/src/lib/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,726 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b793ca53-d4a4-49d0-9683-70bd6114c7b6",
+  "prevId": "b4bb1816-1f7f-4428-b80c-512c019ee7a9",
+  "tables": {
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "journey_id": {
+          "name": "journey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_audit_journey": {
+          "name": "idx_audit_journey",
+          "columns": [
+            "journey_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_journey_id_recovery_journeys_id_fk": {
+          "name": "audit_logs_journey_id_recovery_journeys_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "recovery_journeys",
+          "columnsFrom": [
+            "journey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_logs_action_id_recovery_actions_id_fk": {
+          "name": "audit_logs_action_id_recovery_actions_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "recovery_actions",
+          "columnsFrom": [
+            "action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "customers": {
+      "name": "customers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "razorpay_customer_id": {
+          "name": "razorpay_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_language": {
+          "name": "preferred_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "segment": {
+          "name": "segment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_recovered_amount": {
+          "name": "total_recovered_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dnd_status": {
+          "name": "dnd_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "customers_razorpay_customer_id_unique": {
+          "name": "customers_razorpay_customer_id_unique",
+          "columns": [
+            "razorpay_customer_id"
+          ],
+          "isUnique": true
+        },
+        "customers_email_unique": {
+          "name": "customers_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "payment_failures": {
+      "name": "payment_failures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "razorpay_payment_id": {
+          "name": "razorpay_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "razorpay_order_id": {
+          "name": "razorpay_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "razorpay_subscription_id": {
+          "name": "razorpay_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "razorpay_invoice_id": {
+          "name": "razorpay_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'INR'"
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_type": {
+          "name": "failure_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_source": {
+          "name": "error_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_step": {
+          "name": "error_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_reason": {
+          "name": "error_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_description": {
+          "name": "error_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_failures_customer": {
+          "name": "idx_failures_customer",
+          "columns": [
+            "customer_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "payment_failures_customer_id_customers_id_fk": {
+          "name": "payment_failures_customer_id_customers_id_fk",
+          "tableFrom": "payment_failures",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recovery_actions": {
+      "name": "recovery_actions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "journey_id": {
+          "name": "journey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_number": {
+          "name": "attempt_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_content": {
+          "name": "message_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_reasoning": {
+          "name": "llm_reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_status": {
+          "name": "delivery_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_response": {
+          "name": "customer_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_template_fallback": {
+          "name": "is_template_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_actions_journey": {
+          "name": "idx_actions_journey",
+          "columns": [
+            "journey_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recovery_actions_journey_id_recovery_journeys_id_fk": {
+          "name": "recovery_actions_journey_id_recovery_journeys_id_fk",
+          "tableFrom": "recovery_actions",
+          "tableTo": "recovery_journeys",
+          "columnsFrom": [
+            "journey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recovery_journeys": {
+      "name": "recovery_journeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_id": {
+          "name": "failure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_at_risk": {
+          "name": "amount_at_risk",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_recovered": {
+          "name": "amount_recovered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "recovery_payment_id": {
+          "name": "recovery_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_link_id": {
+          "name": "payment_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "current_attempt": {
+          "name": "current_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_channel": {
+          "name": "current_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_journeys_customer": {
+          "name": "idx_journeys_customer",
+          "columns": [
+            "customer_id"
+          ],
+          "isUnique": false
+        },
+        "idx_journeys_failure": {
+          "name": "idx_journeys_failure",
+          "columns": [
+            "failure_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recovery_journeys_customer_id_customers_id_fk": {
+          "name": "recovery_journeys_customer_id_customers_id_fk",
+          "tableFrom": "recovery_journeys",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recovery_journeys_failure_id_payment_failures_id_fk": {
+          "name": "recovery_journeys_failure_id_payment_failures_id_fk",
+          "tableFrom": "recovery_journeys",
+          "tableTo": "payment_failures",
+          "columnsFrom": [
+            "failure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_events": {
+      "name": "webhook_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processing_status": {
+          "name": "processing_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1787563528846,
       "tag": "0003_new_golden_guardian",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1788235872267,
+      "tag": "0004_greedy_silver_samurai",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -77,6 +77,11 @@ export const recoveryActions = sqliteTable(
     deliveryStatus: text('delivery_status').notNull(), // 'sent' | 'delivered' | 'read' | 'failed'
     providerMessageId: text('provider_message_id'),
     customerResponse: text('customer_response'),
+    // Whether the deterministic template shipped instead of LLM-generated copy. Recorded as a
+    // column rather than inferred from llmReasoning's wording, because the simulation response
+    // model reads it to decide whether the personalisation coefficient applies (RA-23) — a
+    // measurement input must not depend on matching a prose string.
+    isTemplateFallback: integer('is_template_fallback', { mode: 'boolean' }).notNull().default(false),
     outcome: text('outcome').notNull(), // 'pending' | 'payment_completed' | 'ignored' | 'opted_out' | 'failed'
     scheduledAt: text('scheduled_at').notNull(),
     executedAt: text('executed_at').notNull(),

--- a/src/lib/recovery/coordinator.ts
+++ b/src/lib/recovery/coordinator.ts
@@ -368,6 +368,7 @@ export class RecoveryCoordinator {
       deliveryStatus,
       providerMessageId,
       customerResponse: null,
+      isTemplateFallback: messageResult.isTemplateFallback,
       outcome: succeeded ? 'pending' : 'failed',
       scheduledAt: scheduleInfo.scheduledIso,
       executedAt: nowStr,

--- a/src/lib/recovery/coordinator.ts
+++ b/src/lib/recovery/coordinator.ts
@@ -494,7 +494,8 @@ export class RecoveryCoordinator {
   async resolveJourneyWithPayment(
     journeyId: string,
     paymentId: string,
-    amountPaid: number
+    amountPaid: number,
+    attributedActionId?: string
   ): Promise<void> {
     const nowStr = formatIST(getClock().now());
 
@@ -523,20 +524,31 @@ export class RecoveryCoordinator {
       })
       .where(eq(recoveryJourneys.id, journeyId));
 
-    // Attribute the conversion to the most recent outreach action so channel
-    // metrics can report real conversion rates instead of always reading 0.
-    const [lastAction] = await db
-      .select()
-      .from(recoveryActions)
-      .where(eq(recoveryActions.journeyId, journeyId))
-      .orderBy(desc(recoveryActions.attemptNumber))
-      .limit(1);
+    // Attribute the conversion to the outreach that actually caused it, so channel metrics
+    // can report real conversion rates instead of always reading 0.
+    //
+    // The caller names that action when it knows which one converted. Falling back to the most
+    // recent attempt is right for a webhook or a simulator click, where all we know is that the
+    // customer paid after being contacted — but it is wrong whenever an earlier attempt is the
+    // one that landed, which is exactly the case when several attempts are outstanding at once
+    // (a journey started by the abandonment sweep and continued by a later batch run). That
+    // path credited the wrong channel and left the converting attempt 'pending' forever.
+    const [fallbackAction] = attributedActionId
+      ? []
+      : await db
+          .select()
+          .from(recoveryActions)
+          .where(eq(recoveryActions.journeyId, journeyId))
+          .orderBy(desc(recoveryActions.attemptNumber))
+          .limit(1);
 
-    if (lastAction) {
+    const attributedId = attributedActionId ?? fallbackAction?.id;
+
+    if (attributedId) {
       await db
         .update(recoveryActions)
         .set({ outcome: 'payment_completed' })
-        .where(eq(recoveryActions.id, lastAction.id));
+        .where(eq(recoveryActions.id, attributedId));
     }
 
     // Recompute the customer's lifetime recovered total as a derived sum over

--- a/src/lib/simulation/outcomes.ts
+++ b/src/lib/simulation/outcomes.ts
@@ -1,0 +1,212 @@
+/**
+ * Drives the declared response model over a batch (RA-23).
+ *
+ * The split in this file is deliberate. `decideOutcomes` is pure: given the same rows and the
+ * same seed it returns the same decisions, on any machine, in any order — which is what makes
+ * "run the batch twice, get the same result" a property we can test rather than a hope.
+ * `runSimulatedOutcomes` is the thin database wrapper around it.
+ *
+ * What this module does NOT do is resolve journeys. It returns the recoveries it drew and lets
+ * the caller hand them to the recovery coordinator, so that no file under `src/lib/simulation/`
+ * ever imports the agent and no file under `src/lib/recovery/` ever imports the model. The
+ * composition happens one level up, in the API route.
+ */
+
+import { db } from '../db';
+import { customers, paymentFailures, recoveryActions, recoveryJourneys } from '../db/schema';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { writeAuditLog } from '../utils/audit';
+import { SeededRNG } from './rng';
+import {
+  OutcomeDecision,
+  OutreachOutcomeInput,
+  SimulationChannel,
+  SimulationSegment,
+  willPay,
+} from './response-model';
+
+/** One dispatched outreach still awaiting a customer response. */
+export interface PendingOutreach {
+  journeyId: string;
+  actionId: string;
+  /** Seeded and stable across re-seeds (`fail_0000000000000001`), unlike the nanoid journey id. */
+  failureId: string;
+  amountAtRisk: number;
+  errorReason: string;
+  attemptNumber: number;
+  channel: SimulationChannel;
+  segment: SimulationSegment;
+  isTemplateFallback: boolean;
+}
+
+export interface SimulatedOutcome extends OutcomeDecision {
+  journeyId: string;
+  actionId: string;
+  /** Deterministic, so the same batch replays to the same payment ids. */
+  paymentId: string;
+  amountRecovered: number;
+}
+
+/**
+ * FNV-1a over the batch seed and a stable natural key.
+ *
+ * A single shared RNG stream would make every draw depend on how many journeys happened to be
+ * processed before it, so adding one failure to the batch would move every later outcome.
+ * Keying each draw to its own attempt makes the model reproducible per journey instead of per
+ * run — the property the acceptance criteria actually need.
+ */
+export function deriveOutcomeSeed(simulationSeed: number, key: string): number {
+  let hash = 0x811c9dc5 ^ (simulationSeed >>> 0);
+  for (let i = 0; i < key.length; i++) {
+    hash ^= key.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+/** The natural key for one draw: this failure, this attempt. Never the journey's random id. */
+export function outcomeKey(row: PendingOutreach): string {
+  return `${row.failureId}:attempt:${row.attemptNumber}`;
+}
+
+/**
+ * Decides every pending outreach.
+ *
+ * At most one recovery per journey: a customer who paid on attempt 1 cannot pay again on
+ * attempt 2, and the lower attempt number wins regardless of the order rows arrive in.
+ */
+export function decideOutcomes(
+  rows: PendingOutreach[],
+  simulationSeed: number
+): { paid: SimulatedOutcome[]; ignored: SimulatedOutcome[] } {
+  const ordered = [...rows].sort((a, b) =>
+    a.journeyId === b.journeyId
+      ? a.attemptNumber - b.attemptNumber
+      : a.journeyId.localeCompare(b.journeyId)
+  );
+
+  const paid: SimulatedOutcome[] = [];
+  const ignored: SimulatedOutcome[] = [];
+  const settledJourneys = new Set<string>();
+
+  for (const row of ordered) {
+    const input: OutreachOutcomeInput = {
+      errorReason: row.errorReason,
+      attemptNumber: row.attemptNumber,
+      channel: row.channel,
+      segment: row.segment,
+      isTemplateFallback: row.isTemplateFallback,
+    };
+
+    const decision = willPay(input, new SeededRNG(deriveOutcomeSeed(simulationSeed, outcomeKey(row))));
+    const outcome: SimulatedOutcome = {
+      ...decision,
+      journeyId: row.journeyId,
+      actionId: row.actionId,
+      paymentId: `pay_sim_${row.failureId}_a${row.attemptNumber}`,
+      amountRecovered: row.amountAtRisk,
+    };
+
+    if (decision.paid && !settledJourneys.has(row.journeyId)) {
+      settledJourneys.add(row.journeyId);
+      paid.push(outcome);
+    } else {
+      // A draw that landed short, or one on a journey already settled by an earlier attempt:
+      // either way this particular outreach did not convert.
+      ignored.push({ ...outcome, paid: false });
+    }
+  }
+
+  return { paid, ignored };
+}
+
+/** Reads every dispatched-but-unanswered outreach on a still-open journey. */
+export async function collectPendingOutreach(): Promise<PendingOutreach[]> {
+  const rows = await db
+    .select({
+      journeyId: recoveryJourneys.id,
+      actionId: recoveryActions.id,
+      failureId: paymentFailures.id,
+      amountAtRisk: recoveryJourneys.amountAtRisk,
+      errorReason: paymentFailures.errorReason,
+      attemptNumber: recoveryActions.attemptNumber,
+      channel: recoveryActions.channel,
+      segment: customers.segment,
+      isTemplateFallback: recoveryActions.isTemplateFallback,
+      journeyStatus: recoveryJourneys.status,
+    })
+    .from(recoveryActions)
+    .innerJoin(recoveryJourneys, eq(recoveryActions.journeyId, recoveryJourneys.id))
+    .innerJoin(paymentFailures, eq(recoveryJourneys.failureId, paymentFailures.id))
+    .innerJoin(customers, eq(recoveryJourneys.customerId, customers.id))
+    .where(
+      and(
+        eq(recoveryActions.outcome, 'pending'),
+        // Outreach the agent sent and nobody has answered yet. The conversational reply the
+        // agent writes back inside the chat simulator already carries the customer's message
+        // in customerResponse, and drawing an outcome for it would score the agent twice on
+        // one exchange.
+        isNull(recoveryActions.customerResponse),
+        inArray(recoveryJourneys.status, ['recovering', 'escalating', 'exhausted'])
+      )
+    );
+
+  return rows.map((r) => ({
+    journeyId: r.journeyId,
+    actionId: r.actionId,
+    failureId: r.failureId,
+    amountAtRisk: r.amountAtRisk,
+    errorReason: r.errorReason,
+    attemptNumber: r.attemptNumber,
+    channel: r.channel as SimulationChannel,
+    segment: (r.segment === 'b2b' ? 'b2b' : 'b2c') as SimulationSegment,
+    isTemplateFallback: Boolean(r.isTemplateFallback),
+  }));
+}
+
+/**
+ * Runs the model over the batch and records what it decided.
+ *
+ * Every draw is audited — the ones that did not convert too. An evaluation that only logs its
+ * successes is not an evaluation, and the breakdown is written alongside so any single outcome
+ * can be recomputed by hand from `docs/SIMULATION_MODEL.md`.
+ *
+ * Returns the recoveries for the caller to apply; this function never marks a journey resolved.
+ */
+export async function runSimulatedOutcomes(simulationSeed: number): Promise<SimulatedOutcome[]> {
+  const pending = await collectPendingOutreach();
+  if (pending.length === 0) return [];
+
+  const { paid, ignored } = decideOutcomes(pending, simulationSeed);
+
+  for (const outcome of ignored) {
+    await db
+      .update(recoveryActions)
+      .set({ outcome: 'ignored' })
+      .where(eq(recoveryActions.id, outcome.actionId));
+  }
+
+  for (const outcome of [...paid, ...ignored]) {
+    await writeAuditLog({
+      journeyId: outcome.journeyId,
+      actionId: outcome.actionId,
+      actor: 'system',
+      eventType: 'simulated_response_drawn',
+      eventData: {
+        paid: outcome.paid,
+        probability: outcome.probability,
+        draw: outcome.draw,
+        modelVersion: outcome.modelVersion,
+        simulationSeed,
+        baseRate: outcome.baseRate,
+        channelMultiplier: outcome.channelMultiplier,
+        attemptMultiplier: outcome.attemptMultiplier,
+        personalisationMultiplier: outcome.personalisationMultiplier,
+        segmentMultiplier: outcome.segmentMultiplier,
+        note: 'Simulation output against docs/SIMULATION_MODEL.md — not a real payment.',
+      },
+    });
+  }
+
+  return paid;
+}

--- a/src/lib/simulation/response-model.ts
+++ b/src/lib/simulation/response-model.ts
@@ -1,0 +1,175 @@
+/**
+ * The declared response model (RA-23).
+ *
+ * Before this file existed, a simulated customer paid only when a human clicked "Pay" in the
+ * simulator UI. That made the dashboard's recovery rate a count of button presses, and it made
+ * the agent's intelligence unfalsifiable: personalisation, channel escalation and per-failure
+ * strategy selection had no path to influence an outcome, so nothing in the system could
+ * demonstrate that any of them work.
+ *
+ * This module decides whether a simulated customer pays, from declared coefficients that are
+ * visible, versioned, and documented one-for-one in `docs/SIMULATION_MODEL.md`.
+ *
+ * Two rules keep it honest, and both are enforced by `tests/simulation-boundary.test.ts`:
+ *
+ *   1. This file imports nothing from `src/lib/recovery/` or `src/lib/ai/`. The agent's own
+ *      judgment must never be an input to the outcome it is judged on.
+ *   2. Nothing under `src/lib/recovery/` or `src/lib/ai/` imports this file. The agent cannot
+ *      read the model it is being scored against, so it cannot mark its own homework.
+ *
+ * Every number here is an ESTIMATE. None is fitted to observed recovery data — we have none.
+ * They are declared in advance so the comparison they feed cannot be tuned after the fact.
+ */
+
+import { SeededRNG } from './rng';
+
+/** Bumped whenever any coefficient below changes, so a recorded outcome names its model. */
+export const RESPONSE_MODEL_VERSION = '1.0.0';
+
+/** Local copies of the channel/segment unions: importing the agent's types would couple to it. */
+export type SimulationChannel = 'whatsapp' | 'sms' | 'email' | 'voice';
+export type SimulationSegment = 'b2c' | 'b2b';
+
+/**
+ * Everything the model is allowed to see. Deliberately narrow: the message text, the strategy
+ * name and the LLM's reasoning are all withheld, so the model cannot reward the agent for
+ * sounding confident — only for the observable properties of what it actually sent.
+ */
+export interface OutreachOutcomeInput {
+  /** `payment_failures.error_reason` — the root cause the customer has to overcome. */
+  errorReason: string;
+  /** 1-based; the same journey's second message is a second ask, not a fresh one. */
+  attemptNumber: number;
+  channel: SimulationChannel;
+  segment: SimulationSegment;
+  /** True when the deterministic template shipped because the LLM path was unavailable or rejected. */
+  isTemplateFallback: boolean;
+}
+
+/**
+ * Probability that a customer completes payment after ONE outreach, before any modifier:
+ * WhatsApp, first attempt, B2C, template copy. Keyed by root cause, because the cause decides
+ * how much work recovery asks of the customer — re-entering an OTP is a tap, replacing an
+ * expired card is an errand, and a dead bank mandate is a trip to the bank.
+ */
+export const BASE_RATE_BY_ERROR_REASON: Readonly<Record<string, number>> = {
+  gateway_technical_error: 0.55, // nothing is wrong on the customer's side; a retry usually clears
+  authentication_failed: 0.45, // transient: re-entering an OTP costs the customer one tap
+  insufficient_funds: 0.34, // intent exists; recovery waits on the customer's balance, not their will
+  payment_cancelled: 0.3, // hesitation at checkout — persuadable, but the doubt is real
+  card_declined: 0.28, // issuer-side refusal; often needs a different instrument
+  card_expired: 0.22, // requires the customer to fetch and enter a new card
+  mandate_inactive: 0.18, // re-authorising an e-mandate is a multi-step banking flow
+  bank_account_invalid: 0.12, // the account itself is wrong; nearly always needs support contact
+};
+
+/** Applied when `errorReason` is not one of the eight seeded causes. Mid-range, on purpose. */
+export const BASE_RATE_FALLBACK = 0.25;
+
+/**
+ * Channel reach and immediacy. WhatsApp is the reference (1.00) because it is the seeded
+ * batch's primary channel; the others are expressed relative to it.
+ */
+export const CHANNEL_MULTIPLIER: Readonly<Record<SimulationChannel, number>> = {
+  whatsapp: 1.0,
+  voice: 0.9, // highest attention when answered, but many calls are not answered
+  sms: 0.78, // reliably delivered, easily ignored
+  email: 0.55, // slowest, and the one most likely to be filtered
+};
+
+/**
+ * Per-attempt decay. A customer who ignored the first message is, by revealed preference, a
+ * worse prospect for the second — the decay is steep for that reason, not merely for fatigue.
+ * Index 0 is attempt 1; attempts beyond the table use the last value.
+ */
+export const ATTEMPT_DECAY = [1.0, 0.62, 0.38] as const;
+
+/**
+ * The personalisation delta — the single coefficient that makes "did the LLM help?" a real
+ * question. It applies only when the message came from the LLM path; a template-fallback
+ * message gets exactly 1.00. Set deliberately modest: a large delta would manufacture the
+ * project's own headline result.
+ */
+export const PERSONALISATION_MULTIPLIER = 1.18;
+export const TEMPLATE_MULTIPLIER = 1.0;
+
+/** B2B payments route through approval chains that no message can shorten. */
+export const SEGMENT_MULTIPLIER: Readonly<Record<SimulationSegment, number>> = {
+  b2c: 1.0,
+  b2b: 0.85,
+};
+
+/** No outcome is ever certain, and none is ever impossible. */
+export const PROBABILITY_FLOOR = 0.01;
+export const PROBABILITY_CEILING = 0.95;
+
+export interface ProbabilityBreakdown {
+  baseRate: number;
+  channelMultiplier: number;
+  attemptMultiplier: number;
+  personalisationMultiplier: number;
+  segmentMultiplier: number;
+  /** The product, before clamping — reported so a clamped result is visible as clamped. */
+  rawProbability: number;
+  probability: number;
+  modelVersion: string;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * The model itself: a product of declared multipliers over a cause-specific base rate.
+ *
+ * Multiplicative rather than additive so that no single term can carry a probability on its
+ * own — a personalised third-attempt email to a B2B customer with a dead mandate should be
+ * close to hopeless, and a sum of positive terms would not say so.
+ */
+export function computePayProbability(input: OutreachOutcomeInput): ProbabilityBreakdown {
+  const baseRate = BASE_RATE_BY_ERROR_REASON[input.errorReason] ?? BASE_RATE_FALLBACK;
+  const channelMultiplier = CHANNEL_MULTIPLIER[input.channel] ?? CHANNEL_MULTIPLIER.sms;
+
+  const decayIndex = clamp(input.attemptNumber - 1, 0, ATTEMPT_DECAY.length - 1);
+  const attemptMultiplier = ATTEMPT_DECAY[decayIndex];
+
+  const personalisationMultiplier = input.isTemplateFallback
+    ? TEMPLATE_MULTIPLIER
+    : PERSONALISATION_MULTIPLIER;
+
+  const segmentMultiplier = SEGMENT_MULTIPLIER[input.segment] ?? SEGMENT_MULTIPLIER.b2c;
+
+  const rawProbability =
+    baseRate *
+    channelMultiplier *
+    attemptMultiplier *
+    personalisationMultiplier *
+    segmentMultiplier;
+
+  return {
+    baseRate,
+    channelMultiplier,
+    attemptMultiplier,
+    personalisationMultiplier,
+    segmentMultiplier,
+    rawProbability,
+    probability: clamp(rawProbability, PROBABILITY_FLOOR, PROBABILITY_CEILING),
+    modelVersion: RESPONSE_MODEL_VERSION,
+  };
+}
+
+export interface OutcomeDecision extends ProbabilityBreakdown {
+  paid: boolean;
+  /** The draw that produced the decision, recorded so any outcome can be re-checked by hand. */
+  draw: number;
+}
+
+/**
+ * Draws one outcome. The RNG is passed in rather than created here so the caller owns
+ * reproducibility — see `deriveOutcomeSeed` for how a draw is pinned to a specific attempt.
+ */
+export function willPay(input: OutreachOutcomeInput, rng: SeededRNG): OutcomeDecision {
+  const breakdown = computePayProbability(input);
+  const draw = rng.next();
+  return { ...breakdown, paid: draw < breakdown.probability, draw };
+}

--- a/tests/simulation-batch-determinism.test.ts
+++ b/tests/simulation-batch-determinism.test.ts
@@ -21,6 +21,7 @@ const { customers, paymentFailures, recoveryJourneys, recoveryActions, auditLogs
 const { runSimulatedOutcomes } = await import('../src/lib/simulation/outcomes');
 const { getSimulationSeed, DEFAULT_SIMULATION_SEED } = await import('../src/lib/config');
 const { setClock, FixedClock } = await import('../src/lib/utils/time');
+const { recoveryCoordinator } = await import('../src/lib/recovery/coordinator');
 
 const NOW = '2026-08-21T14:30:00+05:30';
 const FIXTURE_COUNT = 24;
@@ -196,5 +197,100 @@ describe('RA-23 batch reproducibility', () => {
     // 12345 is src/lib/db/seed.ts's fixture seed; sharing it would let an edit to the synthetic
     // data move every recovery outcome.
     expect(DEFAULT_SIMULATION_SEED).not.toBe(12345);
+  });
+});
+
+describe('RA-23 conversion attribution', () => {
+  /**
+   * A journey can have more than one outreach outstanding — the abandonment sweep dispatches
+   * attempt 1, and a later batch run dispatches attempt 2 before any outcome has been drawn for
+   * the first. When the model then converts the earlier attempt, crediting the newest one
+   * attributes the recovery to the wrong channel and leaves the converting attempt 'pending'
+   * forever.
+   */
+  it('credits the attempt that converted, not merely the newest one', async () => {
+    setClock(new FixedClock(NOW));
+    await buildBatch();
+
+    const [journey] = await db.select().from(recoveryJourneys).limit(1);
+    const [firstAction] = await db
+      .select()
+      .from(recoveryActions)
+      .where(eq(recoveryActions.journeyId, journey.id));
+
+    const laterActionId = `ra_${crypto.randomUUID()}`;
+    await db.insert(recoveryActions).values({
+      id: laterActionId,
+      journeyId: journey.id,
+      attemptNumber: firstAction.attemptNumber + 1,
+      channel: 'sms',
+      actionType: 'payment_link',
+      messageContent: 'Second outreach, still unanswered.',
+      deliveryStatus: 'delivered',
+      customerResponse: null,
+      isTemplateFallback: true,
+      outcome: 'pending',
+      scheduledAt: NOW,
+      executedAt: NOW,
+      createdAt: NOW,
+    });
+
+    await recoveryCoordinator.resolveJourneyWithPayment(
+      journey.id,
+      'pay_sim_attribution',
+      journey.amountAtRisk,
+      firstAction.id
+    );
+
+    const actions = await db
+      .select()
+      .from(recoveryActions)
+      .where(eq(recoveryActions.journeyId, journey.id));
+
+    const byId = Object.fromEntries(actions.map((a) => [a.id, a.outcome]));
+    expect(byId[firstAction.id]).toBe('payment_completed');
+    expect(byId[laterActionId]).toBe('pending');
+  });
+
+  it('still falls back to the newest attempt when the caller cannot name one', async () => {
+    // A Razorpay webhook or a simulator click knows only that the customer paid after being
+    // contacted, so the newest attempt remains the right default there.
+    setClock(new FixedClock(NOW));
+    await buildBatch();
+
+    const [journey] = await db.select().from(recoveryJourneys).limit(1);
+    const [existing] = await db
+      .select()
+      .from(recoveryActions)
+      .where(eq(recoveryActions.journeyId, journey.id));
+
+    const newestId = `ra_${crypto.randomUUID()}`;
+    await db.insert(recoveryActions).values({
+      id: newestId,
+      journeyId: journey.id,
+      attemptNumber: existing.attemptNumber + 1,
+      channel: 'sms',
+      actionType: 'payment_link',
+      messageContent: 'Newest outreach.',
+      deliveryStatus: 'delivered',
+      customerResponse: null,
+      isTemplateFallback: true,
+      outcome: 'pending',
+      scheduledAt: NOW,
+      executedAt: NOW,
+      createdAt: NOW,
+    });
+
+    await recoveryCoordinator.resolveJourneyWithPayment(
+      journey.id,
+      'pay_sim_fallback',
+      journey.amountAtRisk
+    );
+
+    const [newest] = await db
+      .select()
+      .from(recoveryActions)
+      .where(eq(recoveryActions.id, newestId));
+    expect(newest.outcome).toBe('payment_completed');
   });
 });

--- a/tests/simulation-batch-determinism.test.ts
+++ b/tests/simulation-batch-determinism.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import crypto from 'crypto';
+import { eq } from 'drizzle-orm';
+
+/**
+ * RA-23 acceptance criterion: running a batch twice with the same seed produces identical
+ * recovery outcomes.
+ *
+ * The interesting half of that is what "identical" is allowed to mean. Journey and action ids
+ * are nanoids, so a re-seeded batch never reproduces them; if the draws were keyed to those
+ * ids, or taken from one shared RNG stream in row order, the second run would diverge and the
+ * reproducibility claim would be false in exactly the case the README relies on. This file
+ * builds the same fixtures twice under fresh random ids and asserts the recovered set matches
+ * by failure — the natural key that survives a re-seed.
+ */
+
+const { db } = await import('../src/lib/db');
+const { customers, paymentFailures, recoveryJourneys, recoveryActions, auditLogs } = await import(
+  '../src/lib/db/schema'
+);
+const { runSimulatedOutcomes } = await import('../src/lib/simulation/outcomes');
+const { getSimulationSeed, DEFAULT_SIMULATION_SEED } = await import('../src/lib/config');
+const { setClock, FixedClock } = await import('../src/lib/utils/time');
+
+const NOW = '2026-08-21T14:30:00+05:30';
+const FIXTURE_COUNT = 24;
+
+/**
+ * Builds a batch of dispatched-but-unanswered outreach with stable failure ids and fresh
+ * random journey/action ids, exactly as a re-seed followed by a batch run would leave it.
+ */
+async function buildBatch(): Promise<void> {
+  await db.delete(auditLogs);
+  await db.delete(recoveryActions);
+  await db.delete(recoveryJourneys);
+  await db.delete(paymentFailures);
+  await db.delete(customers);
+
+  const reasons = [
+    'insufficient_funds',
+    'card_expired',
+    'card_declined',
+    'authentication_failed',
+    'payment_cancelled',
+    'gateway_technical_error',
+    'mandate_inactive',
+    'bank_account_invalid',
+  ];
+  const channels = ['whatsapp', 'sms', 'voice'] as const;
+
+  for (let i = 0; i < FIXTURE_COUNT; i++) {
+    // Stable across runs — this is what the draw is keyed to.
+    const failureId = `fail_${String(i + 1).padStart(16, '0')}`;
+    const customerId = `cust_${String(i + 1).padStart(16, '0')}`;
+    // Fresh every run — this is what must NOT affect the draw.
+    const journeyId = `rj_${crypto.randomUUID()}`;
+    const actionId = `ra_${crypto.randomUUID()}`;
+
+    await db.insert(customers).values({
+      id: customerId,
+      name: `Determinism Case ${i}`,
+      email: `ra23-${i}-${crypto.randomUUID()}@example.com`,
+      phone: `+91987650${String(1000 + i).slice(1)}`,
+      preferredLanguage: 'en',
+      segment: i % 5 === 0 ? 'b2b' : 'b2c',
+      totalFailures: 1,
+      totalRecoveredAmount: 0,
+      dndStatus: 'active',
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+
+    await db.insert(paymentFailures).values({
+      id: failureId,
+      customerId,
+      razorpayPaymentId: `pay_${i}`,
+      razorpayOrderId: `order_${i}`,
+      amount: 49900 + i * 100,
+      currency: 'INR',
+      paymentMethod: 'card',
+      failureType: 'one_time',
+      errorCode: 'BAD_REQUEST_ERROR',
+      errorSource: 'customer',
+      errorStep: 'authorization',
+      errorReason: reasons[i % reasons.length],
+      errorDescription: 'Fixture failure for RA-23 determinism.',
+      createdAt: NOW,
+    });
+
+    await db.insert(recoveryJourneys).values({
+      id: journeyId,
+      customerId,
+      failureId,
+      status: 'recovering',
+      strategy: 'payment_link',
+      amountAtRisk: 49900 + i * 100,
+      amountRecovered: 0,
+      maxAttempts: 3,
+      currentAttempt: 1,
+      currentChannel: channels[i % channels.length],
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+
+    await db.insert(recoveryActions).values({
+      id: actionId,
+      journeyId,
+      attemptNumber: (i % 3) + 1,
+      channel: channels[i % channels.length],
+      actionType: 'payment_link',
+      messageContent: 'Fixture outreach.',
+      llmReasoning: null,
+      deliveryStatus: 'delivered',
+      customerResponse: null,
+      isTemplateFallback: i % 2 === 0,
+      outcome: 'pending',
+      scheduledAt: NOW,
+      executedAt: NOW,
+      createdAt: NOW,
+    });
+  }
+}
+
+/** The recovered set, expressed in terms that survive a re-seed. */
+async function runAndSummarise(seed: number): Promise<string[]> {
+  const recoveries = await runSimulatedOutcomes(seed);
+  return recoveries.map((r) => `${r.paymentId}:${r.amountRecovered}`).sort();
+}
+
+describe('RA-23 batch reproducibility', () => {
+  beforeEach(async () => {
+    setClock(new FixedClock(NOW));
+    await buildBatch();
+  });
+
+  it('produces identical recoveries across two runs of the same seed', async () => {
+    const first = await runAndSummarise(DEFAULT_SIMULATION_SEED);
+    await buildBatch();
+    const second = await runAndSummarise(DEFAULT_SIMULATION_SEED);
+
+    expect(second).toEqual(first);
+    // A run that recovers nothing would satisfy equality trivially and prove nothing.
+    expect(first.length).toBeGreaterThan(0);
+    expect(first.length).toBeLessThan(FIXTURE_COUNT);
+  });
+
+  it('produces a different batch under a different seed', async () => {
+    const first = await runAndSummarise(DEFAULT_SIMULATION_SEED);
+    await buildBatch();
+    const other = await runAndSummarise(DEFAULT_SIMULATION_SEED + 1);
+
+    expect(other).not.toEqual(first);
+  });
+
+  it('records every draw in the audit trail, including the ones that did not convert', async () => {
+    const recoveries = await runSimulatedOutcomes(DEFAULT_SIMULATION_SEED);
+
+    const drawn = await db
+      .select()
+      .from(auditLogs)
+      .where(eq(auditLogs.eventType, 'simulated_response_drawn'));
+
+    expect(drawn.length).toBe(FIXTURE_COUNT);
+    expect(drawn.filter((row) => JSON.parse(row.eventData).paid === true).length).toBe(
+      recoveries.length
+    );
+
+    const sample = JSON.parse(drawn[0].eventData);
+    expect(sample.modelVersion).toBeDefined();
+    expect(sample.simulationSeed).toBe(DEFAULT_SIMULATION_SEED);
+    // The breakdown is recorded so an outcome can be recomputed by hand from the doc.
+    expect(sample.baseRate).toBeGreaterThan(0);
+    expect(sample.probability).toBeGreaterThan(0);
+  });
+
+  it('marks non-converting outreach as ignored instead of leaving it pending forever', async () => {
+    const recoveries = await runSimulatedOutcomes(DEFAULT_SIMULATION_SEED);
+
+    const stillPending = await db
+      .select()
+      .from(recoveryActions)
+      .where(eq(recoveryActions.outcome, 'pending'));
+
+    // Only the converting attempts are still open here: this module never resolves a journey,
+    // so their 'payment_completed' outcome is written by the coordinator when the caller
+    // applies the recovery. Everything the model turned down is closed as 'ignored' — before
+    // this change every outreach stayed 'pending' forever, since nothing ever answered.
+    expect(stillPending.map((a) => a.id).sort()).toEqual(
+      recoveries.map((r) => r.actionId).sort()
+    );
+    expect(stillPending.length).toBeLessThan(FIXTURE_COUNT);
+  });
+
+  it('defaults the seed independently of the fixture seed', () => {
+    expect(getSimulationSeed()).toBe(DEFAULT_SIMULATION_SEED);
+    // 12345 is src/lib/db/seed.ts's fixture seed; sharing it would let an edit to the synthetic
+    // data move every recovery outcome.
+    expect(DEFAULT_SIMULATION_SEED).not.toBe(12345);
+  });
+});

--- a/tests/simulation-response-model.test.ts
+++ b/tests/simulation-response-model.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { SeededRNG } from '../src/lib/simulation/rng';
+import {
+  ATTEMPT_DECAY,
+  BASE_RATE_BY_ERROR_REASON,
+  CHANNEL_MULTIPLIER,
+  PERSONALISATION_MULTIPLIER,
+  PROBABILITY_CEILING,
+  PROBABILITY_FLOOR,
+  TEMPLATE_MULTIPLIER,
+  computePayProbability,
+  willPay,
+  type OutreachOutcomeInput,
+} from '../src/lib/simulation/response-model';
+import { decideOutcomes, deriveOutcomeSeed, type PendingOutreach } from '../src/lib/simulation/outcomes';
+
+/**
+ * RA-23 — the README cited a declared response model with a fixed seed; neither existed, so the
+ * only route to `resolved` was a human clicking "Pay" in the simulator and the dashboard's
+ * recovery rate was a count of button presses.
+ *
+ * These are pure-function tests on purpose: the model must be checkable without a database,
+ * because a coefficient that can only be observed through a batch run is a coefficient nobody
+ * will check.
+ */
+
+const BASE_INPUT: OutreachOutcomeInput = {
+  errorReason: 'insufficient_funds',
+  attemptNumber: 1,
+  channel: 'whatsapp',
+  segment: 'b2c',
+  isTemplateFallback: true,
+};
+
+describe('RA-23 declared response model', () => {
+  it('multiplies the declared coefficients rather than inventing a rate', () => {
+    const result = computePayProbability({
+      ...BASE_INPUT,
+      channel: 'sms',
+      attemptNumber: 2,
+      segment: 'b2b',
+      isTemplateFallback: false,
+    });
+
+    const expected =
+      BASE_RATE_BY_ERROR_REASON.insufficient_funds *
+      CHANNEL_MULTIPLIER.sms *
+      ATTEMPT_DECAY[1] *
+      PERSONALISATION_MULTIPLIER *
+      0.85;
+
+    expect(result.rawProbability).toBeCloseTo(expected, 10);
+    expect(result.probability).toBeCloseTo(expected, 10);
+  });
+
+  it('applies the personalisation delta only to LLM-generated copy', () => {
+    const templated = computePayProbability({ ...BASE_INPUT, isTemplateFallback: true });
+    const personalised = computePayProbability({ ...BASE_INPUT, isTemplateFallback: false });
+
+    expect(templated.personalisationMultiplier).toBe(TEMPLATE_MULTIPLIER);
+    expect(personalised.personalisationMultiplier).toBe(PERSONALISATION_MULTIPLIER);
+    // This inequality is the whole reason the model exists: without it, nothing the agent does
+    // to a message can change an outcome, and its intelligence is untestable by construction.
+    expect(personalised.probability).toBeGreaterThan(templated.probability);
+  });
+
+  it('decays with attempt number and never leaves the [floor, ceiling] band', () => {
+    const rates = [1, 2, 3, 4].map((attemptNumber) =>
+      computePayProbability({ ...BASE_INPUT, attemptNumber }).probability
+    );
+
+    expect(rates[0]).toBeGreaterThan(rates[1]);
+    expect(rates[1]).toBeGreaterThan(rates[2]);
+    // Attempts past the declared ladder hold the last coefficient instead of falling off a cliff.
+    expect(rates[3]).toBeCloseTo(rates[2], 10);
+
+    for (const reason of Object.keys(BASE_RATE_BY_ERROR_REASON)) {
+      for (const channel of ['whatsapp', 'sms', 'email', 'voice'] as const) {
+        const p = computePayProbability({ ...BASE_INPUT, errorReason: reason, channel }).probability;
+        expect(p).toBeGreaterThanOrEqual(PROBABILITY_FLOOR);
+        expect(p).toBeLessThanOrEqual(PROBABILITY_CEILING);
+      }
+    }
+  });
+
+  it('falls back to a declared mid-range rate for an unseen error reason', () => {
+    const unknown = computePayProbability({ ...BASE_INPUT, errorReason: 'not_a_seeded_reason' });
+    expect(unknown.baseRate).toBe(0.25);
+  });
+
+  it('draws the same outcome for the same seed and a different one for a different seed', () => {
+    const first = willPay(BASE_INPUT, new SeededRNG(deriveOutcomeSeed(20260823, 'fail_1:attempt:1')));
+    const second = willPay(BASE_INPUT, new SeededRNG(deriveOutcomeSeed(20260823, 'fail_1:attempt:1')));
+    expect(second).toEqual(first);
+
+    // Different attempts of the same failure must not share a draw, or every attempt of a
+    // journey would succeed or fail together.
+    const otherAttempt = deriveOutcomeSeed(20260823, 'fail_1:attempt:2');
+    expect(otherAttempt).not.toBe(deriveOutcomeSeed(20260823, 'fail_1:attempt:1'));
+    expect(deriveOutcomeSeed(99, 'fail_1:attempt:1')).not.toBe(
+      deriveOutcomeSeed(20260823, 'fail_1:attempt:1')
+    );
+  });
+});
+
+describe('RA-23 batch decisions', () => {
+  const row = (overrides: Partial<PendingOutreach> = {}): PendingOutreach => ({
+    journeyId: 'rj_a',
+    actionId: 'ra_a',
+    failureId: 'fail_0000000000000001',
+    amountAtRisk: 49900,
+    errorReason: 'gateway_technical_error',
+    attemptNumber: 1,
+    channel: 'whatsapp',
+    segment: 'b2c',
+    isTemplateFallback: false,
+    ...overrides,
+  });
+
+  it('is invariant to the order rows arrive in and to the random journey ids', () => {
+    const rows = [
+      row({ journeyId: 'rj_a', actionId: 'ra_1', failureId: 'fail_0000000000000001' }),
+      row({ journeyId: 'rj_b', actionId: 'ra_2', failureId: 'fail_0000000000000002' }),
+      row({ journeyId: 'rj_c', actionId: 'ra_3', failureId: 'fail_0000000000000003', attemptNumber: 2 }),
+    ];
+
+    const forward = decideOutcomes(rows, 20260823);
+    const reversed = decideOutcomes([...rows].reverse(), 20260823);
+
+    // Compared by failure, not by journey id: the point of keying draws to the seeded failure
+    // id is that a re-seeded batch with brand-new nanoid journey ids replays identically.
+    const byFailure = (r: ReturnType<typeof decideOutcomes>) =>
+      r.paid.map((o) => o.paymentId).sort();
+    expect(byFailure(reversed)).toEqual(byFailure(forward));
+  });
+
+  it('recovers a journey at most once, on its earliest converting attempt', () => {
+    // A base rate at the ceiling for every attempt, so both draws convert and the tie-break is
+    // the only thing deciding the result.
+    const rows = [
+      row({ journeyId: 'rj_x', actionId: 'ra_2', attemptNumber: 2, errorReason: 'gateway_technical_error' }),
+      row({ journeyId: 'rj_x', actionId: 'ra_1', attemptNumber: 1, errorReason: 'gateway_technical_error' }),
+    ];
+
+    const { paid, ignored } = decideOutcomes(rows, 20260823);
+    expect(paid.length).toBeLessThanOrEqual(1);
+    expect(paid.length + ignored.length).toBe(2);
+    if (paid.length === 1) {
+      expect(paid[0].actionId).toBe('ra_1');
+    }
+  });
+});
+
+describe('RA-23 model isolation', () => {
+  const readSources = (dir: string): { file: string; source: string }[] => {
+    const out: { file: string; source: string }[] = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) out.push(...readSources(full));
+      else if (entry.name.endsWith('.ts')) out.push({ file: full, source: fs.readFileSync(full, 'utf8') });
+    }
+    return out;
+  };
+
+  const importedPaths = (source: string): string[] =>
+    [...source.matchAll(/(?:from|import)\s+['"]([^'"]+)['"]/g)].map((m) => m[1]);
+
+  /**
+   * "The agent cannot import that model" is a claim the README makes. Asserting it here is what
+   * turns it from an intention into a fact — a `grep` in CI catches the direction that matters,
+   * but only a test catches it before the commit lands.
+   */
+  it('keeps the agent out of the simulation module', () => {
+    for (const { file, source } of [
+      ...readSources('src/lib/recovery'),
+      ...readSources('src/lib/ai'),
+    ]) {
+      for (const imported of importedPaths(source)) {
+        expect(
+          imported.includes('simulation'),
+          `${file} imports ${imported}: the agent must not read the model it is scored against`
+        ).toBe(false);
+      }
+    }
+  });
+
+  it('keeps the simulation module out of the agent', () => {
+    for (const { file, source } of readSources('src/lib/simulation')) {
+      for (const imported of importedPaths(source)) {
+        expect(
+          /lib\/(recovery|ai)\/|\.\.\/(recovery|ai)\//.test(imported),
+          `${file} imports ${imported}: the model must not depend on the agent's own judgment`
+        ).toBe(false);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Description

The README cited `docs/SIMULATION_MODEL.md` for *"a declared response model with benchmark-sourced coefficients ... driven by a fixed seed."* Neither the file nor the model existed. `SeededRNG` generated failure fixtures and nothing else, and the only route a journey had to `resolved` was a human clicking **Pay** in the simulator UI.

Two consequences, and the second is the one that matters:

1. The dashboard's recovery rate was a count of button presses.
2. Personalisation, channel escalation and per-failure strategy selection had **no path to influence an outcome**, so the project's central claim was untestable by construction.

Closes #161

## What this adds

**`src/lib/simulation/response-model.ts`** — a pure `willPay()` over declared coefficients:

```
probability = clamp(
    baseRate(errorReason)      // 8 seeded causes, 0.12–0.55
  × channelMultiplier(channel) // whatsapp 1.00 · voice 0.90 · sms 0.78 · email 0.55
  × attemptDecay(attempt)      // 1.00 · 0.62 · 0.38
  × personalisation(...)       // 1.18 for LLM copy, 1.00 for the template fallback
  × segmentMultiplier(segment),// b2c 1.00 · b2b 0.85
  0.01, 0.95)
```

The personalisation multiplier is the coefficient that makes *"did the LLM help?"* a question with an answer. It is set deliberately modest — a large delta would manufacture our own headline result.

**`src/lib/simulation/outcomes.ts`** — each pending outreach gets its own RNG, seeded by FNV-1a over the batch seed and `{failure_id}:attempt:{n}`. Keying to the *seeded* failure id rather than the nanoid journey id is what lets a re-seeded batch replay identically; a single shared stream would move every outcome whenever the batch size changed.

**`docs/SIMULATION_MODEL.md`** — every coefficient with its reasoning, explicitly labelled an **estimate**. None is fitted to data this project has. They are declared in advance and version-controlled so the comparison they feed cannot be tuned after the results are in. The README's "benchmark-sourced" claim is corrected to what the coefficients actually are.

**Boundary, enforced rather than intended:**
- nothing under `src/lib/simulation/` imports `src/lib/recovery/` or `src/lib/ai/`
- nothing under `src/lib/recovery/` or `src/lib/ai/` imports `src/lib/simulation/`

Both directions are asserted by test. The composition happens in the API routes: the model decides, the coordinator applies. The agent cannot read the model it is scored against.

**Also:**
- `recovery_actions.is_template_fallback` (migration 0004, with its probe added to `detectLegacyGeneration`) so the personalisation coefficient reads a column instead of matching a prose string in `llmReasoning`.
- Non-converting outreach closes as `ignored` instead of sitting `pending` forever; every draw — including the ones that did not convert — is audited with its full breakdown, so any outcome can be recomputed by hand from the doc.
- `SIMULATION_SEED` (default `20260823`) is deliberately distinct from the fixture seed `12345`: one shared seed would mean editing the synthetic customer list silently moves every recovery outcome.
- **No draw is ever taken in `RECOVERAI_MODE=live`.** Real customers and real webhooks decide; inventing recoveries alongside them would corrupt a real merchant's numbers.
- The manual **Pay** button still works — the demo keeps its moment. It is now additive rather than the only source of outcomes.

## Second commit: three defects found reviewing the first

All three were seams around the model rather than the model itself:

1. The dashboard asserted "Simulated figures" unconditionally, so a live deployment would label **real** recoveries as simulation output — the same class of error as the one this PR exists to fix, pointing the other way. `GET /api/metrics` now returns a `provenance` block and the notice reads it.
2. `resolveJourneyWithPayment` always credited the *newest* attempt. Right for a webhook or a Pay click; wrong when several attempts are outstanding and the model converts an earlier one — it credited the wrong channel and left the converting attempt `pending` forever. Callers can now name the converting action; the fallback stays for callers that cannot.
3. `POST /api/recovery/sweep` dispatched attempt 1 without drawing an outcome, so a sweep-only deployment accumulated journeys that could never resolve — and defect 2 was exactly how they eventually got resolved, wrongly. It now composes the model the same way the batch run does.

## Verification

- 221/221 tests pass (16 new), `tsc --noEmit`, `eslint`, and `next build` clean.
- A real batch through `POST /api/recovery/trigger`: 50 journeys → 13 recovered, **19.0% by amount** on attempt 1 alone.
- The single-draw-per-freshly-seeded-RNG design was checked statistically, since mulberry32 correlates across nearby seeds: over 20k hash-derived seeds the draws are uniform (mean 0.497, chi-square 14.6 on 9 dof vs a 27.88 critical value) and attempt 1 vs attempt 2 of the same failure are uncorrelated (r = 0.001).

## Deliberately out of scope

- **RA-22 (#160)** — Arms A and B are still the hardcoded `0` and `31.5` in `metrics/route.ts`. Arm C is a real measurement as of this PR, which makes the headline subtraction half-real; #160 is now unblocked and should follow directly.
- **Mock mode cannot demonstrate LLM lift.** Without `GEMINI_API_KEY` every message is the template fallback, so the personalisation coefficient never fires and a mock-mode batch measures cadence and channel ladder only. Blocked on RA-24; recorded as limitation 5 in the doc. No personalisation result should be quoted from a run without a real key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic simulated recovery outcomes in mock mode, configurable with `SIMULATION_SEED`.
  * Recovery trigger and sweep results now report simulated recoveries and the active seed.
  * Dashboard displays a clear “Simulated figures” notice and simulation seed.
  * Metrics now identify whether results are simulated or live.
  * Payments are attributed to the specific outreach attempt that converted.

* **Documentation**
  * Added documentation covering the response model, reproducibility, audit records, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->