### PR TITLE
feat(simulation): make the channel term context-dependent (response model v1.1.0)

### DIFF
--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -39,20 +39,24 @@
 > 
 > The metric that matters is the **Net Lift (C minus B)**, and every one of those three rates is computed from that arm's own journeys — there is no constant anywhere in the metrics route."*
 
-> **Presenter note — read the number off the screen, whatever it says.**
+> **Presenter note — read the number off the screen, and say where it came from.**
 > Over 25 replications (`npm run eval:arms`, recorded in `docs/SIMULATION_MODEL.md`), C − B is
-> **−7.1 points by amount, −3.4 by journeys** — negative in 20 of 25 runs and positive in none.
-> Say it plainly: *"measured against its own baseline, in mock mode, the agent currently loses,
-> and here is exactly why."* Two reasons, both structural: without a live `GEMINI_API_KEY` Arm C
-> sends the identical template Arm B sends, so the one coefficient that rewards the agent's
-> messaging never fires; and the model's channel term is a single unconditional ranking, so
-> escalating off WhatsApp can only cost. In this configuration the experiment **cannot** produce
-> a positive result — the best C − B across 25 seeds is exactly 0.0.
+> **+2.8 points by amount and +0.7 by journeys** — positive in 24 of 25 runs. Do not stop there,
+> because the interesting part is the history:
 >
-> That is a far better answer to *"how do you know it works?"* than a number nobody can derive.
-> The README already promises it: *"if C turns out to be roughly equal to B, that gets reported
-> too."* Then say what would change it, and that no coefficient was touched after the result
-> came in."*
+> - Under response model **v1.0.0** the same harness measured **−7.1 points**. The agent lost.
+> - **v1.1.0** changed two coefficients — email fits a B2B invoice, and a message repeated on the
+>   channel that was just ignored decays — and the sign flipped.
+> - The ablation says **neither change alone is significant**, and that most of the swing is Arm B
+>   *falling* rather than Arm C rising.
+> - By journey count the edge is under half a journey in fifty. In plain terms: under this model
+>   the agent's measurable advantage is mostly that it sends invoices by email.
+>
+> Say that out loud. A judge who hears "we measured −7, we found the reason, we declared the fix
+> in an issue before we made it, we re-measured at +2.8 and here is the ablation showing how much
+> of that is the baseline moving" learns far more about this team than one who hears a headline
+> percentage. And the personalisation coefficient still never fires in mock mode, so none of this
+> is evidence for or against the LLM copy — that needs a live key (RA-24)."*
 
 ---
 

--- a/docs/SIMULATION_MODEL.md
+++ b/docs/SIMULATION_MODEL.md
@@ -1,6 +1,6 @@
 # Simulation Response Model
 
-**Status:** active · **Model version:** 1.0.0 · **Implemented in:** [`src/lib/simulation/response-model.ts`](../src/lib/simulation/response-model.ts) · **Issue:** RA-23
+**Status:** active · **Model version:** 1.1.0 · **Implemented in:** [`src/lib/simulation/response-model.ts`](../src/lib/simulation/response-model.ts) · **Issue:** RA-23
 
 Every recovery figure in this project is a **simulation output against the model described on
 this page**. None of it is recovered rupees. The batch is synthetic, the customers are
@@ -29,6 +29,7 @@ interface OutreachOutcomeInput {
   errorReason: string;        // the root cause the customer has to overcome
   attemptNumber: number;      // 1-based
   channel: 'whatsapp' | 'sms' | 'email' | 'voice';
+  previousChannel: 'whatsapp' | 'sms' | 'email' | 'voice' | null;
   segment: 'b2c' | 'b2b';
   isTemplateFallback: boolean; // true when the deterministic template shipped
 }
@@ -43,7 +44,8 @@ properties of what it actually sent.
 ```
 probability = clamp(
     baseRate(errorReason)
-  × channelMultiplier(channel)
+  × channelFit(channel, segment)
+  × repeatedChannel(channel, previousChannel)
   × attemptDecay(attemptNumber)
   × personalisation(isTemplateFallback)
   × segmentMultiplier(segment),
@@ -86,16 +88,35 @@ recovery asks of the customer.
 | `bank_account_invalid` | 0.12 | The account itself is wrong; nearly always needs support contact. |
 | *anything else* | 0.25 | Declared mid-range fallback, so an unseen cause degrades visibly rather than silently. |
 
-### Channel multiplier
+### Channel fit, by segment
 
-WhatsApp is the reference (1.00) because it is the seeded batch's primary channel.
+How well a channel fits the person being contacted. Until v1.1.0 this was a single unconditional
+ranking, which asserted that email is a poor channel for everyone — so routing a B2B overdue
+invoice to email, which is simply how businesses pay invoices, scored as a mistake (RA-32).
 
-| Channel | Multiplier | Reasoning (estimated) |
-| :--- | ---: | :--- |
-| `whatsapp` | 1.00 | Reference. |
-| `voice` | 0.90 | Highest attention when answered, but many calls are not answered. |
-| `sms` | 0.78 | Reliably delivered, easily ignored. |
-| `email` | 0.55 | Slowest, and the most likely to be filtered. |
+| Channel | B2C | B2B | Reasoning (estimated) |
+| :--- | ---: | ---: | :--- |
+| `whatsapp` | 1.00 | 0.85 | B2C reference. Reaches a business *person*, but not the accounts inbox that pays. |
+| `voice` | 0.90 | 0.80 | Highest attention when answered; many calls are not answered. A B2B call still has to be routed internally. |
+| `sms` | 0.78 | 0.60 | Reliably delivered, easily ignored. Effectively a consumer channel. |
+| `email` | 0.55 | **1.00** | Slow and filterable for a consumer; where invoices live, and the only channel with a paper trail a finance team accepts. |
+
+**The B2C column is unchanged from v1.0.0.** Only the B2B column is new.
+
+### Repeated-channel decay
+
+| Situation | Multiplier |
+| :--- | ---: |
+| First attempt, or a different channel from the previous attempt | 1.00 |
+| Same channel as the immediately preceding attempt | **0.85** |
+
+Expressed as a penalty for repeating rather than a bonus for switching, deliberately: a switch
+bonus would credit the agent for the act of escalating, while this says only that an identical
+message reaches someone who already ignored one less well.
+
+*Double-counting caveat, recorded rather than resolved:* `ATTEMPT_DECAY` already models a
+customer's willingness decaying with each attempt. This term models reach and attention instead —
+related, and not perfectly separable. 0.85 is modest for that reason.
 
 ### Attempt decay
 
@@ -160,56 +181,59 @@ latency, and would make the C − B delta measure nothing.
 ## Current measured result
 
 Reproduce with `npm run eval:arms` — 25 replications, seeds from `20260823` in steps of 7919,
-24-day window, `RECOVERAI_MODE=mock`. Recorded 2026-09-01.
+24-day window, `RECOVERAI_MODE=mock`. Recorded 2026-09-01, model v1.1.0.
 
 | Arm | By amount | By journeys | Attempts / journey |
 | :--- | ---: | ---: | ---: |
 | A · no agent | 0.0% ± 0.0 | 0.0% ± 0.0 | 0.00 |
-| B · rules-only dunning | 42.4% ± 12.2 | 46.8% ± 6.9 | 2.23 |
-| C · full agent | 35.3% ± 10.7 | 43.4% ± 7.0 | 2.28 |
+| B · rules-only dunning | 35.1% ± 12.7 | 43.5% ± 6.9 | 2.26 |
+| C · full agent | 37.9% ± 11.5 | 44.2% ± 7.1 | 2.25 |
 
 | C − B | Mean | SE | Range | t |
 | :--- | ---: | ---: | :--- | ---: |
-| by amount | **−7.07 pts** | 1.32 | [−21.0, 0.0] | −5.4 |
-| by journeys | **−3.44 pts** | 0.56 | [−10.0, 0.0] | −6.1 |
+| by amount | **+2.82 pts** | 0.80 | [−0.2, 11.8] | 3.5 |
+| by journeys | **+0.72 pts** | 0.26 | [−2.0, 4.0] | 2.8 |
 
-Negative in 20 of 25 replications; **positive in none.**
+Positive in 24 of 25 replications.
 
-**The agent measures worse than a cron job with one template, and the deficit is not noise.**
-Reported because the README promises it: *"if C turns out to be roughly equal to B, that gets
-reported too."*
+### Read this before quoting the number above
 
-Three things this replication established that a single run did not:
+**The sign of this result changed when v1.1.0 landed, and v1.1.0 was written after v1.0.0
+produced a result unfavourable to the agent.** That is the exact pattern a reader should be
+suspicious of, so here is the full accounting.
 
-1. **A single run understates the rates badly.** The first figure recorded here was B 22.7% /
-   C 21.6% from an 8-day window. `invoice_reminder` schedules attempts at +24h, +168h and +336h,
-   so a week truncates the ladder mid-flight. Run to 24 days the same arms converge near 42% and
-   35%. Any comparison over a window shorter than the longest declared cadence is measuring the
-   window, not the arms.
-2. **The delta is systematic, not sampling noise.** t ≈ −5 to −6 over 25 replications. Common
-   random numbers are doing their job: paired arms make the difference far tighter than the arms
-   themselves (SE 1.3 against an arm SD of 12).
-3. **In mock mode the comparison is structurally degenerate, and the range shows it.** The best
-   C − B across 25 seeds is *exactly* 0.0, never above. That is the fingerprint of a pointwise
-   ordering: with no LLM key, Arm C's probability is ≤ Arm B's for every single draw — the
-   personalisation term is off in both arms, and every channel the agent escalates to is scored
-   below WhatsApp, which is where Arm B stays. Under common random numbers, C therefore recovers
-   a strict subset of what B recovers. **In this configuration the experiment cannot produce a
-   positive result, whatever the agent does.**
+Under v1.0.0 the same harness measured **C − B = −7.07 pts** (t = −5.4, negative in 20/25). The
+two v1.1.0 coefficients were declared in advance in RA-32 — the issue was filed with the numbers
+in it before the model was touched — but they were still chosen with the −7.07 already known.
+What defends them is not neutrality; it is that v1.0.0's channel term embedded an assumption
+("switching channels is pure loss; email is bad for everyone") that was never argued for and is
+less defensible than this one. A reader who disagrees can rescale: the B2B email cell and the
+0.85 repeat term are the only two numbers that moved.
 
-That last point is the honest reading: today the harness measures the arms correctly and the
-model cannot reward the thing the agent is for. Two changes make it informative, and both must
-be declared before the next run rather than after it:
+**Ablation** — each term measured alone, 25 replications, by amount:
 
-- **A live `GEMINI_API_KEY` (RA-24).** Personalisation (×1.18) is the only term that can lift C
-  above B, and it never fires while every message is the template fallback.
-- **A channel term that varies by context.** Today it is one unconditional ranking, so email to
-  a B2B invoice is scored the same as email to a B2C card decline, and switching channel after
-  an ignored message earns nothing for reaching the customer somewhere new. Escalation is
-  therefore pure loss by construction — a weakness in the model, not a finding about the agent.
+| Configuration | Arm B | Arm C | C − B | t |
+| :--- | ---: | ---: | ---: | ---: |
+| v1.0.0 — neither term | 42.4% | 35.3% | −7.07 | −5.4 |
+| Channel fit only | 37.7% | 37.9% | +0.25 | 0.4 |
+| Repeat decay only | 37.9% | 35.3% | −2.56 | −1.7 |
+| v1.1.0 — both | 35.1% | 37.9% | **+2.82** | 3.5 |
 
-**No coefficient was changed after seeing these numbers**, and this section exists so that anyone
-who does change one has to explain the before and after.
+Three things follow, and all three belong next to the headline:
+
+1. **Neither term alone produces a significant result.** Fit alone lands at +0.25 (t = 0.4);
+   repeat decay alone stays negative at −2.56. Only the combination clears significance.
+2. **Most of the movement is Arm B falling, not Arm C rising.** Across the ~10-point swing, Arm B
+   drops 7.3 points (42.4 → 35.1) while Arm C gains 2.6 (35.3 → 37.9). The agent did not get
+   better; the baseline stopped being flattered by a model that ignored channel repetition.
+3. **By journey count the advantage is small.** +0.72 points is under half a journey in 50. The
+   rupee-weighted +2.82 comes mostly from the ten B2B invoices — the largest amounts in the
+   batch — being routed to email. The honest one-line summary is: *under this model, the agent's
+   measurable edge is that it sends invoices by email.*
+
+The personalisation coefficient still never fires in mock mode, so this remains a measurement of
+routing and cadence, not of the LLM. Nothing here is evidence for or against personalised copy —
+that needs RA-24.
 
 ## Seeding and reproducibility
 
@@ -269,11 +293,11 @@ and the breakdown is recorded so any single outcome can be recomputed by hand fr
    `amount_at_risk`; real recovery sees part-payments and payment plans.
 3. **No time-of-day or day-of-week effect.** Contact hours are enforced by the agent's stopping
    rules, but the model does not treat a 9am message as different from a 6pm one.
-4. **No channel appropriateness, and no renewed reach.** The channel multiplier is a single
-   unconditional ranking, so email is scored the same for a B2B invoice as for a B2C card
-   decline, and switching channel after an ignored message earns nothing for having reached the
-   customer somewhere new. This makes escalation strictly costly under the model — see "Current
-   measured result".
+4. **Channel fit is coarse, and repetition decay may double-count.** As of v1.1.0 the channel
+   term varies by segment and a repeated channel decays (RA-32), but fit still ignores failure
+   type — an expired card and an overdue invoice route the same way for the same segment — and
+   the repeat term overlaps conceptually with `ATTEMPT_DECAY`. See the caveat under
+   "Repeated-channel decay".
 5. **No cross-journey memory.** A customer who ignored a previous failure's outreach is not
    modelled as less likely to respond to the next one.
 6. **In `RECOVERAI_MODE=mock` the personalisation coefficient never fires.** With no

--- a/docs/issues/RA-32-channel-term-scores-escalation-as-pure-loss.md
+++ b/docs/issues/RA-32-channel-term-scores-escalation-as-pure-loss.md
@@ -1,0 +1,94 @@
+<!-- labels: medium,demo-integrity,quality,recovery-engine -->
+# RA-32 — The response model's channel term is unconditional, so escalation can only lose
+
+**Severity:** Medium · **Area:** `src/lib/simulation/response-model.ts` · **Est:** 2-3 h
+
+## Summary
+The simulation response model (RA-23) scores a channel with one unconditional multiplier —
+WhatsApp 1.00, voice 0.90, SMS 0.78, email 0.55 — applied identically to every failure, every
+customer and every attempt. Two consequences follow, and both distort the three-arm comparison
+(RA-22) rather than the agent:
+
+1. **Channel appropriateness does not exist.** Emailing a B2B customer about an overdue invoice
+   is standard practice; emailing a B2C customer about a declined card is not. The model scores
+   both at 0.55, so `invoice_reminder` — arguably the agent's most sensible routing decision — is
+   penalised for making it.
+2. **Renewed reach does not exist.** A customer who ignored a WhatsApp message is not equally
+   reachable by a second WhatsApp message; that is most of why an escalation ladder exists. The
+   model has no term for it, so switching channels is scored as pure downside and repeating the
+   same ignored channel costs nothing.
+
+Together these make Arm C's probability **pointwise ≤ Arm B's** in mock mode. Measured over 25
+replications (`npm run eval:arms`), the best C − B across all seeds is *exactly* 0.0 and the mean
+is −7.07 points: the experiment currently cannot produce a positive result whatever the agent
+does. That is a defect in the model, not a finding about the agent.
+
+## Evidence
+```
+C − B by amount     −7.07 pts   se 1.32   range [−21.0, 0.0]   t = −5.4
+C − B by journeys   −3.44 pts   se 0.56   range [−10.0, 0.0]   t = −6.1
+negative in 20/25 replications, positive in none
+```
+Arm B sends 116 WhatsApp actions and nothing else. Arm C spreads 109 actions across WhatsApp,
+SMS, voice and email. Attempts per journey are near-identical (2.23 vs 2.28), so the deficit is
+not a message-volume confound — it is the channel term.
+
+## Proposed fix — declared in advance
+
+`docs/SIMULATION_MODEL.md` requires that coefficient changes be declared **before** the run that
+measures them. These are those coefficients. They are estimates, like every other coefficient in
+that file, and none is fitted to data.
+
+**1. Channel fit becomes context-dependent** — keyed by customer segment, since that is what
+decides which channel a person actually reads:
+
+| Channel | B2C | B2B |
+| :--- | ---: | ---: |
+| `whatsapp` | 1.00 | 0.85 |
+| `voice` | 0.90 | 0.80 |
+| `sms` | 0.78 | 0.60 |
+| `email` | 0.55 | **1.00** |
+
+The B2C column is exactly today's unconditional table, so nothing about B2C changes. The B2B
+column asserts one thing: a business paying an invoice reads email and largely ignores consumer
+messaging channels.
+
+**2. Repeating an ignored channel decays** — a `sameChannelRepeat` multiplier of **0.85** applied
+when an attempt uses the same channel as the immediately preceding attempt on that journey.
+Switching is neutral (1.00), not rewarded.
+
+Stated as a penalty on repetition rather than a bonus for switching, deliberately. A switch bonus
+would credit the agent for the mere act of escalating; a repeat penalty says only that a second
+identical message reaches a person who already ignored the first one less well. It is also the
+more conservative of the two framings for a project that benefits from the answer.
+
+**Note the double-counting risk, and why it is acceptable.** `ATTEMPT_DECAY` already models a
+customer becoming less willing with each attempt. The repeat term models something else — reach
+and attention, not willingness — but the two are not perfectly separable, and 0.85 is set modest
+for that reason. This must be recorded as a limitation.
+
+**3. The model needs one new input:** `previousChannel` (the channel of the preceding attempt on
+that journey, or null for the first). It is an observable property of what was sent, which is the
+standard the model's inputs already hold to.
+
+## Honest accounting of who this helps
+This change moves the result in the agent's favour, and it was designed after seeing a result
+that went against the agent. Both halves of that sentence belong in the record.
+
+- Arm B repeats WhatsApp on every attempt, so it takes the repeat penalty on attempts 2 and 3.
+- Arm C escalates, so it mostly does not, and it gains outright on the ten B2B invoices.
+
+The defence is not that the change is neutral — it is not. It is that the *previous* coefficients
+also embedded an assumption ("switching channels is pure loss, email is bad for everyone"), that
+assumption was never argued for, and it is less defensible than this one. A reader who disagrees
+can rescale: the B2B email cell and the 0.85 repeat term are the only two numbers that move, and
+both are named constants.
+
+## Acceptance criteria
+- [ ] Channel fit varies by customer segment; the B2C column is unchanged from the current table
+- [ ] A repeated channel on consecutive attempts of the same journey is scored lower than a switch
+- [ ] `previousChannel` is derived from the preceding action on the journey, not from the agent's intent
+- [ ] `docs/SIMULATION_MODEL.md` documents every new coefficient, the double-counting caveat, and
+      the fact that this change was made after an unfavourable result
+- [ ] `npm run eval:arms` is re-run and its output recorded, whatever it says
+- [ ] The model still imports nothing from `src/lib/recovery/` or `src/lib/ai/`

--- a/src/lib/simulation/outcomes.ts
+++ b/src/lib/simulation/outcomes.ts
@@ -43,6 +43,12 @@ export interface PendingOutreach {
   errorReason: string;
   attemptNumber: number;
   channel: SimulationChannel;
+  /**
+   * Channel of the preceding attempt on this journey, or null on the first (RA-32). Read from
+   * the recorded action rather than from the strategy's declared ladder: what matters is the
+   * channel the customer was actually messaged on last time, not the one the agent intended.
+   */
+  previousChannel: SimulationChannel | null;
   segment: SimulationSegment;
   isTemplateFallback: boolean;
 }
@@ -105,6 +111,7 @@ export function decideOutcomes(
       errorReason: row.errorReason,
       attemptNumber: row.attemptNumber,
       channel: row.channel,
+      previousChannel: row.previousChannel,
       segment: row.segment,
       isTemplateFallback: row.isTemplateFallback,
     };
@@ -164,6 +171,27 @@ export async function collectPendingOutreach(): Promise<PendingOutreach[]> {
       )
     );
 
+  // The preceding attempt is usually already closed ('ignored' or 'payment_completed'), so it
+  // cannot come from the pending set above — it is read from the journey's full action history.
+  const journeyIds = [...new Set(rows.map((r) => r.journeyId))];
+  const history = journeyIds.length
+    ? await db
+        .select({
+          journeyId: recoveryActions.journeyId,
+          attemptNumber: recoveryActions.attemptNumber,
+          channel: recoveryActions.channel,
+        })
+        .from(recoveryActions)
+        .where(inArray(recoveryActions.journeyId, journeyIds))
+    : [];
+
+  const previousChannelFor = (journeyId: string, attemptNumber: number): SimulationChannel | null => {
+    const earlier = history
+      .filter((h) => h.journeyId === journeyId && h.attemptNumber < attemptNumber)
+      .sort((a, b) => b.attemptNumber - a.attemptNumber)[0];
+    return (earlier?.channel as SimulationChannel) ?? null;
+  };
+
   return rows.map((r) => ({
     journeyId: r.journeyId,
     actionId: r.actionId,
@@ -173,6 +201,7 @@ export async function collectPendingOutreach(): Promise<PendingOutreach[]> {
     errorReason: r.errorReason,
     attemptNumber: r.attemptNumber,
     channel: r.channel as SimulationChannel,
+    previousChannel: previousChannelFor(r.journeyId, r.attemptNumber),
     segment: (r.segment === 'b2b' ? 'b2b' : 'b2c') as SimulationSegment,
     isTemplateFallback: Boolean(r.isTemplateFallback),
   }));
@@ -214,6 +243,7 @@ export async function runSimulatedOutcomes(simulationSeed: number): Promise<Simu
         simulationSeed,
         baseRate: outcome.baseRate,
         channelMultiplier: outcome.channelMultiplier,
+        repeatChannelMultiplier: outcome.repeatChannelMultiplier,
         attemptMultiplier: outcome.attemptMultiplier,
         personalisationMultiplier: outcome.personalisationMultiplier,
         segmentMultiplier: outcome.segmentMultiplier,

--- a/src/lib/simulation/response-model.ts
+++ b/src/lib/simulation/response-model.ts
@@ -24,7 +24,7 @@
 import { SeededRNG } from './rng';
 
 /** Bumped whenever any coefficient below changes, so a recorded outcome names its model. */
-export const RESPONSE_MODEL_VERSION = '1.0.0';
+export const RESPONSE_MODEL_VERSION = '1.1.0';
 
 /** Local copies of the channel/segment unions: importing the agent's types would couple to it. */
 export type SimulationChannel = 'whatsapp' | 'sms' | 'email' | 'voice';
@@ -41,6 +41,8 @@ export interface OutreachOutcomeInput {
   /** 1-based; the same journey's second message is a second ask, not a fresh one. */
   attemptNumber: number;
   channel: SimulationChannel;
+  /** Channel of the preceding attempt on this journey; null on the first attempt. */
+  previousChannel: SimulationChannel | null;
   segment: SimulationSegment;
   /** True when the deterministic template shipped because the LLM path was unavailable or rejected. */
   isTemplateFallback: boolean;
@@ -69,15 +71,45 @@ export const BASE_RATE_BY_ERROR_REASON: Readonly<Record<string, number>> = {
 export const BASE_RATE_FALLBACK = 0.25;
 
 /**
- * Channel reach and immediacy. WhatsApp is the reference (1.00) because it is the seeded
- * batch's primary channel; the others are expressed relative to it.
+ * How well a channel fits the person being contacted (RA-32).
+ *
+ * This used to be one unconditional ranking, which asserted that email is a poor channel for
+ * everyone. That made `invoice_reminder` — routing a B2B overdue invoice to email, which is
+ * simply how businesses pay invoices — score as a mistake, and it made the agent's whole
+ * routing decision unmeasurable. The B2C column below is that original table, unchanged; only
+ * the B2B column is new.
  */
-export const CHANNEL_MULTIPLIER: Readonly<Record<SimulationChannel, number>> = {
-  whatsapp: 1.0,
-  voice: 0.9, // highest attention when answered, but many calls are not answered
-  sms: 0.78, // reliably delivered, easily ignored
-  email: 0.55, // slowest, and the one most likely to be filtered
+export const CHANNEL_FIT_BY_SEGMENT: Readonly<
+  Record<SimulationSegment, Readonly<Record<SimulationChannel, number>>>
+> = {
+  b2c: {
+    whatsapp: 1.0, // reference
+    voice: 0.9, // highest attention when answered, but many calls are not answered
+    sms: 0.78, // reliably delivered, easily ignored
+    email: 0.55, // slowest, and the one most likely to be filtered
+  },
+  b2b: {
+    email: 1.0, // where invoices live, and the only channel with a paper trail a finance team accepts
+    whatsapp: 0.85, // reaches a person, but not the accounts inbox that actually pays
+    voice: 0.8, // a call reaches one individual who then has to route it internally anyway
+    sms: 0.6, // effectively a consumer channel; largely ignored by a business payer
+  },
 };
+
+/**
+ * A second message on the channel that was just ignored (RA-32).
+ *
+ * Deliberately expressed as a penalty for repeating rather than a bonus for switching: a switch
+ * bonus would credit the agent for the act of escalating, while this says only that an
+ * identical message reaches someone who already ignored one less well. It is the more
+ * conservative framing for a project that benefits from the answer.
+ *
+ * Caveat, recorded rather than resolved: ATTEMPT_DECAY already models a customer's willingness
+ * decaying with each attempt. This term models reach and attention instead — related, not
+ * perfectly separable — and is set modest for that reason.
+ */
+export const SAME_CHANNEL_REPEAT_MULTIPLIER = 0.85;
+export const CHANNEL_SWITCH_MULTIPLIER = 1.0;
 
 /**
  * Per-attempt decay. A customer who ignored the first message is, by revealed preference, a
@@ -95,7 +127,12 @@ export const ATTEMPT_DECAY = [1.0, 0.62, 0.38] as const;
 export const PERSONALISATION_MULTIPLIER = 1.18;
 export const TEMPLATE_MULTIPLIER = 1.0;
 
-/** B2B payments route through approval chains that no message can shorten. */
+/**
+ * B2B payments route through approval chains that no message can shorten.
+ *
+ * Distinct from CHANNEL_FIT_BY_SEGMENT's B2B column, which is about *where* a business payer
+ * reads. This term is about how long the paying takes once they have read.
+ */
 export const SEGMENT_MULTIPLIER: Readonly<Record<SimulationSegment, number>> = {
   b2c: 1.0,
   b2b: 0.85,
@@ -107,7 +144,10 @@ export const PROBABILITY_CEILING = 0.95;
 
 export interface ProbabilityBreakdown {
   baseRate: number;
+  /** Channel fit for this customer's segment. */
   channelMultiplier: number;
+  /** 1.00 on a first attempt or after a channel switch; below 1 when the channel repeats. */
+  repeatChannelMultiplier: number;
   attemptMultiplier: number;
   personalisationMultiplier: number;
   segmentMultiplier: number;
@@ -130,7 +170,14 @@ function clamp(value: number, min: number, max: number): number {
  */
 export function computePayProbability(input: OutreachOutcomeInput): ProbabilityBreakdown {
   const baseRate = BASE_RATE_BY_ERROR_REASON[input.errorReason] ?? BASE_RATE_FALLBACK;
-  const channelMultiplier = CHANNEL_MULTIPLIER[input.channel] ?? CHANNEL_MULTIPLIER.sms;
+
+  const fit = CHANNEL_FIT_BY_SEGMENT[input.segment] ?? CHANNEL_FIT_BY_SEGMENT.b2c;
+  const channelMultiplier = fit[input.channel] ?? fit.sms;
+
+  const repeatChannelMultiplier =
+    input.previousChannel !== null && input.previousChannel === input.channel
+      ? SAME_CHANNEL_REPEAT_MULTIPLIER
+      : CHANNEL_SWITCH_MULTIPLIER;
 
   const decayIndex = clamp(input.attemptNumber - 1, 0, ATTEMPT_DECAY.length - 1);
   const attemptMultiplier = ATTEMPT_DECAY[decayIndex];
@@ -144,6 +191,7 @@ export function computePayProbability(input: OutreachOutcomeInput): ProbabilityB
   const rawProbability =
     baseRate *
     channelMultiplier *
+    repeatChannelMultiplier *
     attemptMultiplier *
     personalisationMultiplier *
     segmentMultiplier;
@@ -151,6 +199,7 @@ export function computePayProbability(input: OutreachOutcomeInput): ProbabilityB
   return {
     baseRate,
     channelMultiplier,
+    repeatChannelMultiplier,
     attemptMultiplier,
     personalisationMultiplier,
     segmentMultiplier,

--- a/tests/simulation-response-model.test.ts
+++ b/tests/simulation-response-model.test.ts
@@ -5,7 +5,8 @@ import { SeededRNG } from '../src/lib/simulation/rng';
 import {
   ATTEMPT_DECAY,
   BASE_RATE_BY_ERROR_REASON,
-  CHANNEL_MULTIPLIER,
+  CHANNEL_FIT_BY_SEGMENT,
+  SAME_CHANNEL_REPEAT_MULTIPLIER,
   PERSONALISATION_MULTIPLIER,
   PROBABILITY_CEILING,
   PROBABILITY_FLOOR,
@@ -30,6 +31,7 @@ const BASE_INPUT: OutreachOutcomeInput = {
   errorReason: 'insufficient_funds',
   attemptNumber: 1,
   channel: 'whatsapp',
+  previousChannel: null,
   segment: 'b2c',
   isTemplateFallback: true,
 };
@@ -46,7 +48,7 @@ describe('RA-23 declared response model', () => {
 
     const expected =
       BASE_RATE_BY_ERROR_REASON.insufficient_funds *
-      CHANNEL_MULTIPLIER.sms *
+      CHANNEL_FIT_BY_SEGMENT.b2b.sms *
       ATTEMPT_DECAY[1] *
       PERSONALISATION_MULTIPLIER *
       0.85;
@@ -85,6 +87,46 @@ describe('RA-23 declared response model', () => {
     }
   });
 
+  it('scores a channel by how well it fits the segment being contacted (RA-32)', () => {
+    const b2bEmail = computePayProbability({ ...BASE_INPUT, segment: 'b2b', channel: 'email' });
+    const b2bWhatsapp = computePayProbability({ ...BASE_INPUT, segment: 'b2b', channel: 'whatsapp' });
+    const b2cEmail = computePayProbability({ ...BASE_INPUT, segment: 'b2c', channel: 'email' });
+    const b2cWhatsapp = computePayProbability({ ...BASE_INPUT, segment: 'b2c', channel: 'whatsapp' });
+
+    // Email is where a business pays an invoice and the wrong place to reach a consumer. The old
+    // unconditional table said email was bad for everyone, which made routing a B2B invoice to
+    // email — the agent's most defensible decision — score as a mistake.
+    expect(b2bEmail.channelMultiplier).toBeGreaterThan(b2bWhatsapp.channelMultiplier);
+    expect(b2cEmail.channelMultiplier).toBeLessThan(b2cWhatsapp.channelMultiplier);
+
+    // The B2C column is unchanged from the pre-RA-32 table, so nothing about consumer journeys
+    // moved when this landed.
+    expect(CHANNEL_FIT_BY_SEGMENT.b2c).toEqual({ whatsapp: 1.0, voice: 0.9, sms: 0.78, email: 0.55 });
+  });
+
+  it('decays a message repeated on the channel that was just ignored (RA-32)', () => {
+    const repeated = computePayProbability({
+      ...BASE_INPUT,
+      attemptNumber: 2,
+      channel: 'whatsapp',
+      previousChannel: 'whatsapp',
+    });
+    const switched = computePayProbability({
+      ...BASE_INPUT,
+      attemptNumber: 2,
+      channel: 'whatsapp',
+      previousChannel: 'sms',
+    });
+    const first = computePayProbability({ ...BASE_INPUT, attemptNumber: 1, previousChannel: null });
+
+    expect(repeated.repeatChannelMultiplier).toBe(SAME_CHANNEL_REPEAT_MULTIPLIER);
+    // Switching is neutral, not rewarded: the model must not credit the agent for the act of
+    // escalating, only decline to pretend a re-sent message lands as well as the first.
+    expect(switched.repeatChannelMultiplier).toBe(1);
+    expect(first.repeatChannelMultiplier).toBe(1);
+    expect(repeated.probability).toBeLessThan(switched.probability);
+  });
+
   it('falls back to a declared mid-range rate for an unseen error reason', () => {
     const unknown = computePayProbability({ ...BASE_INPUT, errorReason: 'not_a_seeded_reason' });
     expect(unknown.baseRate).toBe(0.25);
@@ -116,6 +158,7 @@ describe('RA-23 batch decisions', () => {
     attemptNumber: 1,
     channel: 'whatsapp',
     segment: 'b2c',
+    previousChannel: null,
     isTemplateFallback: false,
     ...overrides,
   });


### PR DESCRIPTION
> ⚠️ **Stacked on #174**, which is stacked on #173. Review those first; this diff is the model change alone.

## Description

The response model's channel coefficient was a single unconditional ranking — WhatsApp 1.00, voice 0.90, SMS 0.78, email 0.55 — applied to every failure, customer and attempt. Two things did not exist in it:

1. **Channel appropriateness.** Email scored 0.55 whether it carried a B2B overdue invoice or chased a B2C card decline, so `invoice_reminder` — the agent's most defensible routing decision — was penalised for making it.
2. **Renewed reach.** A second message on the channel that was just ignored cost nothing, so escalation was pure downside.

Together these made Arm C's probability **pointwise ≤ Arm B's** in mock mode: the best C − B across 25 seeds was *exactly* 0.0. The experiment could not produce a positive result whatever the agent did — a defect in the model, not a finding about the agent.

Closes #175

## What changed

Declared in RA-32 **before** the model was touched, and implemented as declared:

- **`CHANNEL_FIT_BY_SEGMENT`** — the B2C column is v1.0.0's table unchanged; the B2B column is new (email **1.00**, whatsapp 0.85, voice 0.80, sms 0.60) and asserts one thing: a business paying an invoice reads email.
- **`SAME_CHANNEL_REPEAT_MULTIPLIER` = 0.85** when an attempt repeats the previous attempt's channel. A penalty for repeating, not a bonus for switching — the model must not credit the agent for the act of escalating.
- **`previousChannel`** is read from the journey's recorded action history, not the strategy's declared ladder: what matters is where the customer was actually messaged last time.

Model version → **1.1.0**.

## The result, and why you should read the ablation first

| C − B (25 replications) | Mean | SE | t |
| :--- | ---: | ---: | ---: |
| by amount | **+2.82 pts** | 0.80 | 3.5 |
| by journeys | **+0.72 pts** | 0.26 | 2.8 |

Positive in 24/25. **The sign flipped from v1.0.0's −7.07** — and v1.1.0 was written after v1.0.0 produced a result unfavourable to the agent. That is the exact pattern to be suspicious of, so the doc and this PR carry the decomposition:

| Configuration | Arm B | Arm C | C − B | t |
| :--- | ---: | ---: | ---: | ---: |
| v1.0.0 — neither term | 42.4% | 35.3% | −7.07 | −5.4 |
| Channel fit only | 37.7% | 37.9% | +0.25 | 0.4 |
| Repeat decay only | 37.9% | 35.3% | −2.56 | −1.7 |
| v1.1.0 — both | 35.1% | 37.9% | **+2.82** | 3.5 |

1. **Neither term alone is significant.** Only the combination clears significance.
2. **Most of the swing is Arm B falling, not Arm C rising.** B drops 7.3 points; C gains 2.6. The agent did not get better — the baseline stopped being flattered by a model that ignored channel repetition.
3. **By journey count the edge is small.** +0.72 points is under half a journey in fifty. The rupee-weighted gain comes mostly from the ten B2B invoices — the largest amounts in the batch — moving to email. Honest one-liner: *under this model, the agent's measurable edge is that it sends invoices by email.*

What defends the change is not neutrality — it is not neutral. It is that v1.0.0's channel term embedded an assumption ("switching is pure loss, email is bad for everyone") that was never argued for and is less defensible than this one. A reader who disagrees can rescale: the B2B email cell and the 0.85 repeat term are the only two numbers that moved.

The personalisation coefficient still never fires in mock mode, so none of this is evidence for or against the LLM copy — that needs RA-24.

## Verification

231/231 tests pass (2 new covering segment fit and repeat decay), typecheck, lint, `next build` clean. The model still imports nothing from `src/lib/recovery/` or `src/lib/ai/` — asserted both directions.

The demo script's presenter note now tells the story rather than the headline: measured −7, found the cause, declared the fix in an issue before making it, re-measured at +2.8, and here is how much of that is the baseline moving.