### PR TITLE
feat(simulator): wire the virtual clock to demo controls

### DIFF
--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -12,7 +12,7 @@
 | :--- | :--- | :--- | :--- |
 | **0:00 – 0:45** | **Hook & The Problem** | Title slide / Hero Dashboard with ₹ at Risk | Razorpay merchants lose 15–20% of GMV to avoidable declines. Static dunning has low conversion; non-compliant outreach risks heavy penalties. |
 | **0:45 – 1:45** | **Executive Dashboard & 3-Arm Lift** | Navigate `/` → Highlight Metrics Cards & 3-Arm Chart | 6 Real-time KPIs. Three-arm comparison over one seeded batch, every rate measured from that arm's own journeys. **Read the lift off the screen — do not quote a number from this script.** |
-| **1:45 – 2:45** | **Multi-Channel Escalation & Audit** | Click "Customers" → Open "Audit Timeline" Modal | WhatsApp (Attempt 1) → SMS (Attempt 2) → AI Voice (Attempt 3). Expand immutable audit logs showing raw payloads and Gemini reasoning. |
+| **1:45 – 2:45** | **Multi-Channel Escalation, Contact Hours & Audit** | `/simulator` → advance the clock to 21:00 IST, run the agent, advance to 09:00 → "Customers" → Audit Timeline | WhatsApp (Attempt 1) → SMS (Attempt 2) → AI Voice (Attempt 3). Outreach **defers** after 19:00 IST with a logged reason, then resumes in the morning. Immutable audit logs, including the `clock_advanced` rows. |
 | **2:45 – 3:45** | **Interactive Sandbox & Stopping Rules** | Navigate `/simulator` → Select customer → Trigger "Pay Now" & "STOP" | Dual-panel testbed. Live payment link settlement; instant STOP opt-out compliance (Stopping Rule #2); live IST RBI contact hours clock (8AM–7PM). |
 | **3:45 – 4:30** | **OpenSSF Security & Architecture** | Show test suite (`npm test`) & CI workflows | Timing-safe HMAC verification (`crypto.timingSafeEqual`), DPDPA zero PII in prompts, append-only audit trail, 21/21 automated invariant tests. |
 | **4:30 – 5:00** | **Summary & Business ROI** | Return to Overview Dashboard | RecoverAI turns failed payments into settled revenue without risking customer trust or compliance. |
@@ -60,8 +60,26 @@
 
 ---
 
-### [1:45 – 2:45] Multi-Channel Escalation & Immutable Audit Ledger
-> *(Click "Customers & Audit" → Click "Audit Timeline" on Aarav Sharma)*
+### [1:45 – 2:45] Contact Hours, Escalation & the Immutable Audit Ledger
+> *(Start on `/simulator`. Use the **Simulated Clock** controls — RA-31.)*
+>
+> *"The compliance story is the part you cannot see in a five-minute demo, because it plays out
+> over days. So we move the clock instead of faking the result.*
+>
+> **1. Jump to 21:00 IST** — click *21:00 (after hours)*, then *Run AI Recovery Agent*.
+> *"It is now past nine at night. The RBI Fair Practices contact window closes at 7pm, so the
+> agent dispatches nothing. Every deferral is logged with the rule that fired — it did not fail,
+> it declined."*
+>
+> **2. Jump to 09:00 the next morning** — click *09:00 (next morning)*, then *Run AI Recovery Agent*.
+> *"Same queue, same agent, twelve hours later. Now it dispatches — WhatsApp first, then SMS on
+> the second attempt, then a voice call on the third."*
+>
+> **3. Open the audit trail** — *(Click "Customers & Audit" → "Audit Timeline" on Aarav Sharma)*
+> *"Every jump I just made is in the ledger as a `clock_advanced` row — who moved time, from
+> when, to when. The clock only moves forward, so nothing can be replayed to inflate a number,
+> and the only way back to real time is reseeding, which deletes the journeys first. You are
+> looking at simulated time, and the trail says so."*
 > *"Every customer journey follows an escalation ladder:
 > 1. **Attempt 1**: WhatsApp Interactive Message with a direct Razorpay payment link.
 > 2. **Attempt 2**: Personalized SMS with regional language support.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -141,7 +141,7 @@
 
 | # | Task | Status | Owner | Notes |
 | :--- | :--- | :--- | :--- | :--- |
-| 8.1 | Injectable `Clock` + virtual clock controls | ✅ | Agent | `src/lib/utils/time.ts` with `Clock`, `SystemClock`, `FixedClock`, `VirtualClock` |
+| 8.1 | Injectable `Clock` + virtual clock controls | ✅ | Agent | `src/lib/utils/time.ts` + `src/lib/utils/demo-clock.ts`; `POST /api/simulator/clock`, forward-only, `clock_advanced` audit row, simulator control (RA-31) |
 | 8.2 | Documented customer response model | ✅ | Agent | `src/lib/simulation/response-model.ts` + `docs/SIMULATION_MODEL.md`; coefficients are declared estimates, not benchmark citations (RA-23) |
 | 8.3 | Baseline comparison harness (arms A/B/C) | ✅ | Agent | `payment_failures.arm` cohorts + per-arm rates in `src/app/api/metrics/route.ts`; all three measured from their own journeys, C − B reported signed (RA-22) |
 | 8.4 | Checkout abandonment sweep job | ✅ | Agent | `src/lib/recovery/abandonment-sweep.ts` & `/api/recovery/sweep` |

--- a/src/app/api/simulator/clock/route.ts
+++ b/src/app/api/simulator/clock/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  ClockDirectionError,
+  ClockInputError,
+  advanceDemoClock,
+  getClockState,
+} from '@/lib/utils/demo-clock';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Demo clock controls (RA-31). Sits under /api/simulator/* so it inherits that surface's
+ * guard: on a production build it answers 404 unless RECOVERAI_DEMO_MODE is explicitly on.
+ * Moving time is a demo affordance, and a deployment taking real Razorpay traffic must not
+ * expose it at all.
+ */
+export async function GET() {
+  return NextResponse.json({ success: true, data: getClockState() });
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const { advanceMinutes, toIso } = body as { advanceMinutes?: number; toIso?: string };
+
+    const result = await advanceDemoClock({ advanceMinutes, toIso });
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        ...result,
+        message: `Advanced ${result.advancedMinutes} minutes: ${result.fromIso} → ${result.toIso}`,
+      },
+    });
+  } catch (error: unknown) {
+    if (error instanceof ClockDirectionError) {
+      return NextResponse.json(
+        { success: false, error: { code: 'CLOCK_BACKWARDS', message: error.message } },
+        { status: 409 }
+      );
+    }
+    if (error instanceof ClockInputError) {
+      return NextResponse.json(
+        { success: false, error: { code: 'INVALID_INPUT', message: error.message } },
+        { status: 400 }
+      );
+    }
+
+    const message = error instanceof Error ? error.message : 'Error advancing the demo clock';
+    console.error('[POST /api/simulator/clock]', error);
+    return NextResponse.json(
+      { success: false, error: { code: 'CLOCK_ERROR', message } },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/simulator/seed/route.ts
+++ b/src/app/api/simulator/seed/route.ts
@@ -1,11 +1,17 @@
 import { NextResponse } from 'next/server';
 import { seedDatabase } from '@/lib/db/seed';
+import { resetDemoClock } from '@/lib/utils/demo-clock';
 
 export const dynamic = 'force-dynamic';
 
 export async function POST() {
   try {
     const count = await seedDatabase();
+
+    // Reseeding is the only way back to real time (RA-31). The demo clock refuses to move
+    // backwards on its own because rewinding past a fired attempt would let the same outreach
+    // replay; a reseed deletes those rows first, so there is nothing left to replay.
+    resetDemoClock();
     return NextResponse.json({
       success: true,
       data: {

--- a/src/components/simulator/BatchControls.tsx
+++ b/src/components/simulator/BatchControls.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -10,6 +10,8 @@ import {
   Send,
   Loader2,
   CheckCircle2,
+  Clock,
+  FastForward,
 } from 'lucide-react';
 
 interface BatchControlsProps {
@@ -21,6 +23,87 @@ export function BatchControls({ onActionComplete }: BatchControlsProps) {
   const [isRecovering, setIsRecovering] = useState(false);
   const [isSendingWebhook, setIsSendingWebhook] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [clockIso, setClockIso] = useState<string | null>(null);
+  const [isVirtualClock, setIsVirtualClock] = useState(false);
+  const [isAdvancing, setIsAdvancing] = useState(false);
+
+  const loadClock = useCallback(async () => {
+    try {
+      const res = await fetch('/api/simulator/clock');
+      const json = await res.json();
+      if (json.success) {
+        setClockIso(json.data.nowIso);
+        setIsVirtualClock(json.data.isVirtual);
+      }
+    } catch (err) {
+      console.error('Clock read error:', err);
+    }
+  }, []);
+
+  // Mirrors the dashboard's mount fetch: the request is issued inside the effect and the state
+  // is set from its callback, so the effect body itself performs no synchronous setState.
+  useEffect(() => {
+    let isMounted = true;
+    (async () => {
+      try {
+        const res = await fetch('/api/simulator/clock');
+        const json = await res.json();
+        if (isMounted && json.success) {
+          setClockIso(json.data.nowIso);
+          setIsVirtualClock(json.data.isVirtual);
+        }
+      } catch (err) {
+        console.error('Clock read error:', err);
+      }
+    })();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  /**
+   * Moves simulated time forward (RA-31). The contact window and the retry ladder play out over
+   * days, so without this the two most defensible behaviours in the system cannot be shown in a
+   * five-minute demo. Every advance is written to the audit trail, and time never moves back —
+   * rewinding past a fired attempt would let the same outreach replay.
+   */
+  const handleAdvanceClock = async (body: { advanceMinutes?: number; toIso?: string }, label: string) => {
+    setIsAdvancing(true);
+    setStatusMessage(`Advancing simulated time ${label}...`);
+    try {
+      const res = await fetch('/api/simulator/clock', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const json = await res.json();
+      if (json.success) {
+        setClockIso(json.data.state.nowIso);
+        setIsVirtualClock(true);
+        setStatusMessage(json.data.message);
+        onActionComplete();
+      } else {
+        setStatusMessage(`Clock error: ${json.error?.message}`);
+      }
+    } catch (err) {
+      console.error('Clock advance error:', err);
+      setStatusMessage('Failed to advance the demo clock.');
+    } finally {
+      setIsAdvancing(false);
+    }
+  };
+
+  /** Next occurrence of an IST hour, so "jump to 21:00" always moves forward. */
+  const nextIstHourIso = (hour: number): string | undefined => {
+    if (!clockIso) return undefined;
+    const current = new Date(clockIso);
+    const [datePart] = clockIso.split('T');
+    let target = new Date(`${datePart}T${String(hour).padStart(2, '0')}:00:00+05:30`);
+    if (target.getTime() <= current.getTime()) {
+      target = new Date(target.getTime() + 24 * 60 * 60 * 1000);
+    }
+    return target.toISOString();
+  };
 
   const handleSeed = async () => {
     setIsSeeding(true);
@@ -30,6 +113,7 @@ export function BatchControls({ onActionComplete }: BatchControlsProps) {
       const json = await res.json();
       if (json.success) {
         setStatusMessage(`Successfully seeded ${json.data.count} synthetic failure records!`);
+        await loadClock(); // the seed route returns the process to real time
         onActionComplete();
       } else {
         setStatusMessage(`Error seeding: ${json.error?.message}`);
@@ -171,6 +255,65 @@ export function BatchControls({ onActionComplete }: BatchControlsProps) {
               <span className="text-[10px] text-indigo-100">Process queue & escalate channels</span>
             </div>
           </Button>
+        </div>
+
+        {/* Demo clock (RA-31) */}
+        <div className="pt-2 border-t border-zinc-100 dark:border-zinc-800 space-y-2">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-xs font-semibold text-zinc-700 dark:text-zinc-300 flex items-center gap-1.5">
+              <Clock className="w-3.5 h-3.5 text-zinc-500" />
+              Simulated Clock (IST)
+            </div>
+            <span className="text-[11px] font-mono text-zinc-600 dark:text-zinc-400">
+              {clockIso ? clockIso.replace('T', ' ').replace('+05:30', '') : '—'}
+              {isVirtualClock && (
+                <span className="ml-1.5 text-[10px] uppercase font-semibold text-amber-600 dark:text-amber-400">
+                  virtual
+                </span>
+              )}
+            </span>
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+            {[
+              { label: '+1 hour', body: { advanceMinutes: 60 } },
+              { label: '+24 hours', body: { advanceMinutes: 60 * 24 } },
+            ].map((option) => (
+              <Button
+                key={option.label}
+                variant="outline"
+                size="sm"
+                onClick={() => handleAdvanceClock(option.body, option.label)}
+                disabled={isAdvancing}
+                className="text-xs justify-start h-8"
+              >
+                <FastForward className="w-3.5 h-3.5 mr-1.5 text-zinc-600" />
+                {option.label}
+              </Button>
+            ))}
+            {[
+              { label: '21:00 (after hours)', hour: 21 },
+              { label: '09:00 (next morning)', hour: 9 },
+            ].map((option) => (
+              <Button
+                key={option.label}
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  const toIso = nextIstHourIso(option.hour);
+                  if (toIso) handleAdvanceClock({ toIso }, `to ${option.label}`);
+                }}
+                disabled={isAdvancing || !clockIso}
+                className="text-xs justify-start h-8"
+              >
+                <Clock className="w-3.5 h-3.5 mr-1.5 text-zinc-600" />
+                {option.label}
+              </Button>
+            ))}
+          </div>
+          <p className="text-[10px] text-zinc-500">
+            Forward only, and every advance is written to the audit trail. Reseed to return to
+            real time.
+          </p>
         </div>
 
         {/* Live Webhook Injection Buttons */}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -36,6 +36,7 @@ const GEN = {
   PERF_INDEXES: 3,         // 0003 — idx_* indexes
   TEMPLATE_FALLBACK: 4,    // 0004 — recovery_actions.is_template_fallback
   EXPERIMENT_ARMS: 5,      // 0005 — payment_failures.arm/simulation_key, recovery_journeys.arm
+  NULLABLE_AUDIT_JOURNEY: 6, // 0006 — audit_logs.journey_id becomes nullable
 } as const;
 
 /**
@@ -64,10 +65,17 @@ function detectLegacyGeneration(sqlite: Database.Database): number | null {
   // Already has a ledger: Drizzle can take it from here.
   if (hasTable(MIGRATIONS_TABLE)) return null;
 
-  const hasColumn = (table: string, column: string): boolean =>
-    (sqlite.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[]).some(
+  const columnInfo = (table: string, column: string): { name: string; notnull: number } | undefined =>
+    (sqlite.prepare(`PRAGMA table_info(${table})`).all() as { name: string; notnull: number }[]).find(
       (c) => c.name === column
     );
+
+  const hasColumn = (table: string, column: string): boolean => columnInfo(table, column) !== undefined;
+
+  // 0006 adds no column — it relaxes one. A generation probe therefore has to read the
+  // constraint rather than the column list, or every database would look pre-0006 forever and
+  // the table rebuild would replay on each boot.
+  const isNullable = (table: string, column: string): boolean => columnInfo(table, column)?.notnull === 0;
 
   // Every migration that alters a table needs a probe here, checked newest-first, and the
   // floor must be the base-tables generation. Stamping a database at the generation of a
@@ -82,6 +90,7 @@ function detectLegacyGeneration(sqlite: Database.Database): number | null {
   // leaves the database permanently stale — the exact failure this adoption path exists to
   // repair.
   const when = generationTimestamps();
+  if (isNullable('audit_logs', 'journey_id')) return when[GEN.NULLABLE_AUDIT_JOURNEY];
   if (hasColumn('recovery_journeys', 'arm')) return when[GEN.EXPERIMENT_ARMS];
   if (hasColumn('recovery_actions', 'is_template_fallback')) return when[GEN.TEMPLATE_FALLBACK];
   if (hasColumn('customers', 'razorpay_customer_id')) return when[GEN.RAZORPAY_CUSTOMER_ID];

--- a/src/lib/db/migrations/0006_dashing_slipstream.sql
+++ b/src/lib/db/migrations/0006_dashing_slipstream.sql
@@ -1,0 +1,18 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_audit_logs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`journey_id` text,
+	`action_id` text,
+	`actor` text NOT NULL,
+	`event_type` text NOT NULL,
+	`event_data` text NOT NULL,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`journey_id`) REFERENCES `recovery_journeys`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`action_id`) REFERENCES `recovery_actions`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_audit_logs`("id", "journey_id", "action_id", "actor", "event_type", "event_data", "created_at") SELECT "id", "journey_id", "action_id", "actor", "event_type", "event_data", "created_at" FROM `audit_logs`;--> statement-breakpoint
+DROP TABLE `audit_logs`;--> statement-breakpoint
+ALTER TABLE `__new_audit_logs` RENAME TO `audit_logs`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `idx_audit_journey` ON `audit_logs` (`journey_id`);

--- a/src/lib/db/migrations/meta/0006_snapshot.json
+++ b/src/lib/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,764 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "813fd059-3648-40f9-aead-78d9a6e9fa64",
+  "prevId": "1a4cb5b4-92ce-4353-a704-f8fe3b52cfc4",
+  "tables": {
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "journey_id": {
+          "name": "journey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_audit_journey": {
+          "name": "idx_audit_journey",
+          "columns": [
+            "journey_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_journey_id_recovery_journeys_id_fk": {
+          "name": "audit_logs_journey_id_recovery_journeys_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "recovery_journeys",
+          "columnsFrom": [
+            "journey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_logs_action_id_recovery_actions_id_fk": {
+          "name": "audit_logs_action_id_recovery_actions_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "recovery_actions",
+          "columnsFrom": [
+            "action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "customers": {
+      "name": "customers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "razorpay_customer_id": {
+          "name": "razorpay_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_language": {
+          "name": "preferred_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "segment": {
+          "name": "segment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_recovered_amount": {
+          "name": "total_recovered_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dnd_status": {
+          "name": "dnd_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "customers_razorpay_customer_id_unique": {
+          "name": "customers_razorpay_customer_id_unique",
+          "columns": [
+            "razorpay_customer_id"
+          ],
+          "isUnique": true
+        },
+        "customers_email_unique": {
+          "name": "customers_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "payment_failures": {
+      "name": "payment_failures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "razorpay_payment_id": {
+          "name": "razorpay_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "razorpay_order_id": {
+          "name": "razorpay_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "razorpay_subscription_id": {
+          "name": "razorpay_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "razorpay_invoice_id": {
+          "name": "razorpay_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'INR'"
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_type": {
+          "name": "failure_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_source": {
+          "name": "error_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_step": {
+          "name": "error_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_reason": {
+          "name": "error_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_description": {
+          "name": "error_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "arm": {
+          "name": "arm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'C'"
+        },
+        "simulation_key": {
+          "name": "simulation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_failures_customer": {
+          "name": "idx_failures_customer",
+          "columns": [
+            "customer_id"
+          ],
+          "isUnique": false
+        },
+        "idx_failures_arm": {
+          "name": "idx_failures_arm",
+          "columns": [
+            "arm"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "payment_failures_customer_id_customers_id_fk": {
+          "name": "payment_failures_customer_id_customers_id_fk",
+          "tableFrom": "payment_failures",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recovery_actions": {
+      "name": "recovery_actions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "journey_id": {
+          "name": "journey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_number": {
+          "name": "attempt_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_content": {
+          "name": "message_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_reasoning": {
+          "name": "llm_reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_status": {
+          "name": "delivery_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_response": {
+          "name": "customer_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_template_fallback": {
+          "name": "is_template_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_actions_journey": {
+          "name": "idx_actions_journey",
+          "columns": [
+            "journey_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recovery_actions_journey_id_recovery_journeys_id_fk": {
+          "name": "recovery_actions_journey_id_recovery_journeys_id_fk",
+          "tableFrom": "recovery_actions",
+          "tableTo": "recovery_journeys",
+          "columnsFrom": [
+            "journey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recovery_journeys": {
+      "name": "recovery_journeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_id": {
+          "name": "failure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_at_risk": {
+          "name": "amount_at_risk",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_recovered": {
+          "name": "amount_recovered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "recovery_payment_id": {
+          "name": "recovery_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_link_id": {
+          "name": "payment_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "current_attempt": {
+          "name": "current_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_channel": {
+          "name": "current_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "arm": {
+          "name": "arm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'C'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_journeys_arm": {
+          "name": "idx_journeys_arm",
+          "columns": [
+            "arm"
+          ],
+          "isUnique": false
+        },
+        "idx_journeys_customer": {
+          "name": "idx_journeys_customer",
+          "columns": [
+            "customer_id"
+          ],
+          "isUnique": false
+        },
+        "idx_journeys_failure": {
+          "name": "idx_journeys_failure",
+          "columns": [
+            "failure_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recovery_journeys_customer_id_customers_id_fk": {
+          "name": "recovery_journeys_customer_id_customers_id_fk",
+          "tableFrom": "recovery_journeys",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recovery_journeys_failure_id_payment_failures_id_fk": {
+          "name": "recovery_journeys_failure_id_payment_failures_id_fk",
+          "tableFrom": "recovery_journeys",
+          "tableTo": "payment_failures",
+          "columnsFrom": [
+            "failure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_events": {
+      "name": "webhook_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processing_status": {
+          "name": "processing_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1788239417989,
       "tag": "0005_worthless_nick_fury",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1788250536552,
+      "tag": "0006_dashing_slipstream",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -110,7 +110,10 @@ export const auditLogs = sqliteTable(
   'audit_logs',
   {
     id: text('id').primaryKey(), // prefix: audit_
-    journeyId: text('journey_id').notNull().references(() => recoveryJourneys.id),
+    // Nullable since RA-31: most events belong to a journey, but a process-wide one — the demo
+    // clock being advanced — belongs to no journey, and attaching it to an arbitrary one would
+    // put a false entry in that customer's timeline.
+    journeyId: text('journey_id').references(() => recoveryJourneys.id),
     actionId: text('action_id').references(() => recoveryActions.id),
     actor: text('actor').notNull(), // 'system' | 'agent' | 'customer' | 'razorpay'
     eventType: text('event_type').notNull(),

--- a/src/lib/utils/audit.ts
+++ b/src/lib/utils/audit.ts
@@ -7,7 +7,8 @@ import { maskPiiDeep } from './pii';
 export type AuditActor = 'system' | 'agent' | 'customer' | 'razorpay';
 
 export interface AuditLogParams {
-  journeyId: string;
+  /** Null for process-wide events that belong to no journey, such as a demo clock advance. */
+  journeyId: string | null;
   actionId?: string | null;
   actor: AuditActor;
   eventType: string;
@@ -24,7 +25,7 @@ export async function writeAuditLog(params: AuditLogParams): Promise<string> {
   
   await db.insert(auditLogs).values({
     id: logId,
-    journeyId: params.journeyId,
+    journeyId: params.journeyId ?? null,
     actionId: params.actionId || null,
     actor: params.actor,
     eventType: params.eventType,

--- a/src/lib/utils/demo-clock.ts
+++ b/src/lib/utils/demo-clock.ts
@@ -1,0 +1,151 @@
+/**
+ * The demo clock (RA-31).
+ *
+ * `VirtualClock` existed and nothing referenced it, which meant the two most defensible
+ * behaviours in the project could not be shown to anyone: the 8AM-7PM IST contact window, and
+ * the T+1h / T+24h / T+72h retry ladder. Both play out over days; a demo lasts five minutes.
+ *
+ * Two rules keep this a demo aid rather than a way to fake results:
+ *
+ *   1. **Time only moves forward.** A backwards jump would re-open journeys whose scheduled
+ *      attempts have already fired, so the same outreach could be replayed and counted twice.
+ *      Returning to real time is done by reseeding, which deletes the rows that could replay.
+ *   2. **Every advance is audited.** A `clock_advanced` row records who moved time, from when,
+ *      to when, and by how much — so an evaluator reading the timeline can see exactly where
+ *      time jumped and confirm that no stopping rule was skipped over rather than satisfied.
+ */
+
+import { Clock, SystemClock, VirtualClock, formatIST, getClock, setClock } from './time';
+import { writeAuditLog } from './audit';
+
+export interface ClockState {
+  /** True once this process is running on a virtual clock. */
+  isVirtual: boolean;
+  /**
+   * Offset from real time, in milliseconds. Negative when the demo is pinned to a date in the
+   * past, which the seeded batch is — only the *advances* are constrained to be non-negative.
+   */
+  offsetMs: number;
+  nowIso: string;
+  realNowIso: string;
+}
+
+/** The clock this process is running on, promoted to a VirtualClock on first advance. */
+function asVirtualClock(): VirtualClock {
+  const current: Clock = getClock();
+  if (current instanceof VirtualClock) return current;
+
+  // A test that pinned a FixedClock keeps it: this module must never quietly replace a clock a
+  // caller deliberately installed, or a deterministic test would start drifting.
+  if (!(current instanceof SystemClock)) {
+    throw new Error(
+      '[demo-clock] Refusing to replace a clock installed by the caller. ' +
+        'The demo clock only takes over from SystemClock.'
+    );
+  }
+
+  const virtual = new VirtualClock(0);
+  setClock(virtual);
+  return virtual;
+}
+
+export function getClockState(): ClockState {
+  const current = getClock();
+  const isVirtual = current instanceof VirtualClock;
+  return {
+    isVirtual,
+    offsetMs: isVirtual ? current.getOffset() : 0,
+    nowIso: formatIST(current.now()),
+    realNowIso: formatIST(new Date()),
+  };
+}
+
+export interface AdvanceRequest {
+  /** Move forward by this many minutes. */
+  advanceMinutes?: number;
+  /** Or move to this absolute instant, which must not be in the past of the current clock. */
+  toIso?: string;
+}
+
+export interface AdvanceResult {
+  fromIso: string;
+  toIso: string;
+  advancedMinutes: number;
+  state: ClockState;
+}
+
+export class ClockDirectionError extends Error {}
+export class ClockInputError extends Error {}
+
+/**
+ * Moves the demo clock forward and records it.
+ *
+ * Returns the interval that was skipped, so a caller can say what it jumped over rather than
+ * only where it landed — the difference between "it is now 09:00" and "the twelve hours in
+ * which outreach was deferred have elapsed".
+ */
+export async function advanceDemoClock(request: AdvanceRequest): Promise<AdvanceResult> {
+  const { advanceMinutes, toIso } = request;
+
+  if ((advanceMinutes === undefined) === (toIso === undefined)) {
+    throw new ClockInputError('Provide exactly one of advanceMinutes or toIso.');
+  }
+
+  const clock = asVirtualClock();
+  const from = clock.now();
+
+  let deltaMs: number;
+  if (advanceMinutes !== undefined) {
+    if (!Number.isFinite(advanceMinutes)) {
+      throw new ClockInputError('advanceMinutes must be a finite number.');
+    }
+    deltaMs = Math.round(advanceMinutes * 60 * 1000);
+  } else {
+    const target = new Date(toIso!);
+    if (Number.isNaN(target.getTime())) {
+      throw new ClockInputError(`Unparseable instant: "${toIso}".`);
+    }
+    deltaMs = target.getTime() - from.getTime();
+  }
+
+  if (deltaMs < 0) {
+    throw new ClockDirectionError(
+      `Time only moves forward. Requested ${Math.round(deltaMs / 60000)} minutes from ` +
+        `${formatIST(from)}. Reseed the batch to return to real time.`
+    );
+  }
+
+  clock.advanceBy(deltaMs);
+  const to = clock.now();
+
+  await writeAuditLog({
+    journeyId: null, // a process-wide event; it belongs to no single journey
+    actor: 'system',
+    eventType: 'clock_advanced',
+    eventData: {
+      fromIso: formatIST(from),
+      toIso: formatIST(to),
+      advancedMinutes: Math.round(deltaMs / 60000),
+      offsetMsAfter: clock.getOffset(),
+      reason: 'demo_clock_advance',
+      note: 'Simulated time only. Scheduled work is evaluated against this clock, never skipped.',
+    },
+  });
+
+  return {
+    fromIso: formatIST(from),
+    toIso: formatIST(to),
+    advancedMinutes: Math.round(deltaMs / 60000),
+    state: getClockState(),
+  };
+}
+
+/**
+ * Returns the process to real time. Only safe alongside a reseed — see rule 1 above — so it is
+ * called by the seed route rather than exposed as a control of its own.
+ */
+export function resetDemoClock(): void {
+  if (getClock() instanceof VirtualClock) {
+    setClock(new SystemClock());
+  }
+}

--- a/src/lib/utils/time.ts
+++ b/src/lib/utils/time.ts
@@ -24,19 +24,40 @@ export class FixedClock implements Clock {
   }
 }
 
+/**
+ * A clock that runs at real speed but offset from real time, so a demo can cross a boundary
+ * that would otherwise take days to reach — the 8AM-7PM IST contact window, or the T+1h /
+ * T+24h / T+72h retry ladder (RA-31).
+ *
+ * Offset rather than frozen, deliberately: a frozen clock would make every timestamp in a
+ * demo identical and hide the ordering an evaluator is being asked to read.
+ */
 export class VirtualClock implements Clock {
   private offsetMs = 0;
-  private baseTime: Date | null = null;
+
+  constructor(offsetMs = 0) {
+    this.offsetMs = offsetMs;
+  }
 
   setOffset(ms: number) {
     this.offsetMs = ms;
-    this.baseTime = null;
+  }
+
+  getOffset(): number {
+    return this.offsetMs;
   }
 
   setTime(date: Date | string) {
     const target = typeof date === 'string' ? new Date(date) : date;
     this.offsetMs = target.getTime() - Date.now();
-    this.baseTime = null;
+  }
+
+  /** Moves the clock forward by `ms`. Negative values are rejected — see `demo-clock.ts`. */
+  advanceBy(ms: number) {
+    if (ms < 0) {
+      throw new Error('[VirtualClock] Time only moves forward. Reseed to return to real time.');
+    }
+    this.offsetMs += ms;
   }
 
   now(): Date {
@@ -44,15 +65,23 @@ export class VirtualClock implements Clock {
   }
 }
 
-// Singleton pattern for the clock
-let globalClock: Clock = new SystemClock();
+/**
+ * The clock is a process-wide singleton held on `globalThis`, for the same reason the database
+ * connection is: Next.js re-evaluates route modules on hot reload, and a module-scoped `let`
+ * would silently hand a second copy of the clock to half the routes — so the simulator would
+ * advance a clock the coordinator never reads.
+ */
+const globalForClock = globalThis as unknown as { recoverAiClock: Clock | undefined };
 
 export function getClock(): Clock {
-  return globalClock;
+  if (!globalForClock.recoverAiClock) {
+    globalForClock.recoverAiClock = new SystemClock();
+  }
+  return globalForClock.recoverAiClock;
 }
 
 export function setClock(clock: Clock) {
-  globalClock = clock;
+  globalForClock.recoverAiClock = clock;
 }
 
 /**

--- a/tests/demo-clock.test.ts
+++ b/tests/demo-clock.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import crypto from 'crypto';
+import { eq } from 'drizzle-orm';
+
+/**
+ * RA-31 — `VirtualClock` was defined and referenced by nothing, so the two behaviours the task
+ * board called critical-path — the 8AM-7PM IST contact window and the T+1h/T+24h/T+72h retry
+ * ladder — could not be shown to anyone. Both play out over days; a demo lasts five minutes.
+ *
+ * The test that matters is the last one: outreach deferred at 21:00 IST actually dispatches
+ * once time is advanced to the morning, through the same stopping rules, with no rule skipped.
+ */
+
+const { db } = await import('../src/lib/db');
+const { customers, paymentFailures, recoveryJourneys, recoveryActions, auditLogs } = await import(
+  '../src/lib/db/schema'
+);
+const { recoveryCoordinator } = await import('../src/lib/recovery/coordinator');
+const { getClock, setClock, SystemClock, VirtualClock, FixedClock, formatIST } = await import(
+  '../src/lib/utils/time'
+);
+const { advanceDemoClock, getClockState, resetDemoClock, ClockDirectionError, ClockInputError } =
+  await import('../src/lib/utils/demo-clock');
+const { POST: clockRoute, GET: clockStateRoute } = await import(
+  '../src/app/api/simulator/clock/route'
+);
+const { POST: triggerRecovery } = await import('../src/app/api/recovery/trigger/route');
+
+/** Real time, moved to a known wall-clock instant by offsetting rather than freezing. */
+function startOnVirtualClockAt(iso: string) {
+  setClock(new SystemClock());
+  resetDemoClock();
+  const virtual = new VirtualClock(Date.parse(iso) - Date.now());
+  setClock(virtual);
+  return virtual;
+}
+
+async function seedJourney(): Promise<string> {
+  const suffix = crypto.randomUUID();
+  const customerId = `cust_clock_${suffix}`;
+  const failureId = `fail_clock_${suffix}`;
+  const nowStr = formatIST(getClock().now());
+
+  await db.insert(customers).values({
+    id: customerId,
+    name: 'Clock Fixture',
+    email: `clock-${suffix}@example.com`,
+    phone: '+919876500777',
+    preferredLanguage: 'en',
+    segment: 'b2c',
+    totalFailures: 1,
+    totalRecoveredAmount: 0,
+    dndStatus: 'active',
+    createdAt: nowStr,
+    updatedAt: nowStr,
+  });
+
+  await db.insert(paymentFailures).values({
+    id: failureId,
+    customerId,
+    razorpayPaymentId: `pay_${suffix}`,
+    razorpayOrderId: `order_${suffix}`,
+    amount: 149900,
+    currency: 'INR',
+    paymentMethod: 'card',
+    failureType: 'one_time',
+    errorCode: 'BAD_REQUEST_ERROR',
+    errorSource: 'customer',
+    errorStep: 'authorization',
+    errorReason: 'insufficient_funds',
+    errorDescription: 'Clock fixture failure.',
+    arm: 'C',
+    simulationKey: `sim_clock_${suffix}`,
+    createdAt: nowStr,
+  });
+
+  return recoveryCoordinator.startRecoveryJourney(failureId);
+}
+
+afterAll(() => {
+  setClock(new SystemClock());
+});
+
+describe('RA-31 demo clock', () => {
+  beforeEach(async () => {
+    startOnVirtualClockAt('2026-08-21T14:30:00+05:30');
+    // Audit rows are stamped with the simulated clock, so rows written by an earlier case can
+    // sort *after* this one's. Each case starts from an empty clock_advanced trail instead of
+    // ordering by a timestamp the test itself moves.
+    await db.delete(auditLogs).where(eq(auditLogs.eventType, 'clock_advanced'));
+  });
+
+  it('advances by a relative interval and reports what it skipped', async () => {
+    const before = getClockState();
+    const result = await advanceDemoClock({ advanceMinutes: 90 });
+
+    expect(result.advancedMinutes).toBe(90);
+    expect(result.fromIso).toBe(before.nowIso);
+    expect(Date.parse(result.state.nowIso) - Date.parse(before.nowIso)).toBe(90 * 60 * 1000);
+    // Offset, not frozen: real time keeps running underneath, so timestamps still order. The
+    // offset itself is negative here because the seeded batch is dated in the past — only the
+    // advances are constrained to be forward.
+    expect(result.state.isVirtual).toBe(true);
+    expect(result.state.offsetMs).toBe(before.offsetMs + 90 * 60 * 1000);
+  });
+
+  it('advances to an absolute instant', async () => {
+    const result = await advanceDemoClock({ toIso: '2026-08-21T21:00:00+05:30' });
+    expect(result.state.nowIso.startsWith('2026-08-21T21:00')).toBe(true);
+    expect(result.advancedMinutes).toBe(390);
+  });
+
+  it('refuses to move backwards', async () => {
+    await advanceDemoClock({ advanceMinutes: 60 });
+
+    await expect(advanceDemoClock({ advanceMinutes: -30 })).rejects.toBeInstanceOf(
+      ClockDirectionError
+    );
+    await expect(
+      advanceDemoClock({ toIso: '2026-08-21T09:00:00+05:30' })
+    ).rejects.toBeInstanceOf(ClockDirectionError);
+
+    // Rewinding past a fired attempt would let the same outreach replay and be counted twice,
+    // so the clock stays where it was.
+    expect(getClockState().nowIso.startsWith('2026-08-21T15:30')).toBe(true);
+  });
+
+  it('rejects an ambiguous or unparseable request', async () => {
+    await expect(advanceDemoClock({})).rejects.toBeInstanceOf(ClockInputError);
+    await expect(
+      advanceDemoClock({ advanceMinutes: 10, toIso: '2026-08-21T21:00:00+05:30' })
+    ).rejects.toBeInstanceOf(ClockInputError);
+    await expect(advanceDemoClock({ toIso: 'not-a-date' })).rejects.toBeInstanceOf(ClockInputError);
+  });
+
+  it('records every advance in the audit trail', async () => {
+    await advanceDemoClock({ advanceMinutes: 45 });
+
+    const rows = await db
+      .select()
+      .from(auditLogs)
+      .where(eq(auditLogs.eventType, 'clock_advanced'));
+
+    expect(rows).toHaveLength(1);
+    const [row] = rows;
+    // A process-wide event belongs to no journey; attaching it to one would put a false entry
+    // in that customer's timeline.
+    expect(row.journeyId).toBeNull();
+    expect(row.actor).toBe('system');
+
+    const data = JSON.parse(row.eventData);
+    expect(data.advancedMinutes).toBe(45);
+    expect(data.fromIso).toBeDefined();
+    expect(data.toIso).toBeDefined();
+  });
+
+  it('will not displace a clock the caller installed deliberately', async () => {
+    setClock(new FixedClock('2026-08-21T14:30:00+05:30'));
+    // A test that pinned a FixedClock must keep it, or deterministic suites would start
+    // drifting the moment something touched the demo controls.
+    await expect(advanceDemoClock({ advanceMinutes: 10 })).rejects.toThrow(/Refusing to replace/);
+  });
+
+  it('resumes outreach deferred outside contact hours once time is advanced', async () => {
+    // 21:00 IST: past the 19:00 cutoff, so the agent must defer rather than dispatch.
+    startOnVirtualClockAt('2026-08-21T21:00:00+05:30');
+    const journeyId = await seedJourney();
+
+    const deferredActions = await db
+      .select()
+      .from(recoveryActions)
+      .where(eq(recoveryActions.journeyId, journeyId));
+    expect(deferredActions).toHaveLength(0);
+
+    const deferralLog = await db
+      .select()
+      .from(auditLogs)
+      .where(eq(auditLogs.journeyId, journeyId));
+    expect(
+      deferralLog.some(
+        (row) => row.eventType === 'stopping_rule_triggered' && row.eventData.includes('contact_hours')
+      )
+    ).toBe(true);
+
+    // Advance across the boundary into the next morning.
+    await advanceDemoClock({ toIso: '2026-08-22T09:00:00+05:30' });
+    await recoveryCoordinator.processRecoveryAttempt(journeyId);
+
+    const resumedActions = await db
+      .select()
+      .from(recoveryActions)
+      .where(eq(recoveryActions.journeyId, journeyId));
+
+    // The rule was satisfied, not skipped: the attempt fires only because the clock now reads
+    // a time inside the window, and it is stamped with that time.
+    expect(resumedActions).toHaveLength(1);
+    expect(resumedActions[0].executedAt.startsWith('2026-08-22T09:00')).toBe(true);
+
+    const [journey] = await db
+      .select()
+      .from(recoveryJourneys)
+      .where(eq(recoveryJourneys.id, journeyId));
+    expect(journey.currentAttempt).toBe(1);
+  });
+});
+
+describe('RA-31 clock route', () => {
+  const post = (body: unknown) =>
+    clockRoute(new Request('http://localhost/api/simulator/clock', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }) as never);
+
+  beforeEach(() => {
+    startOnVirtualClockAt('2026-08-21T14:30:00+05:30');
+  });
+
+  it('answers with the current simulated time', async () => {
+    const json = await (await clockStateRoute()).json();
+    expect(json.success).toBe(true);
+    expect(json.data.nowIso.startsWith('2026-08-21T14:30')).toBe(true);
+  });
+
+  it('rejects a backwards jump with 409 and a bad request with 400', async () => {
+    const backwards = await post({ toIso: '2026-08-20T09:00:00+05:30' });
+    expect(backwards.status).toBe(409);
+    expect((await backwards.json()).error.code).toBe('CLOCK_BACKWARDS');
+
+    const ambiguous = await post({});
+    expect(ambiguous.status).toBe(400);
+    expect((await ambiguous.json()).error.code).toBe('INVALID_INPUT');
+  });
+
+  /**
+   * The one that would have failed before this change: the route and the coordinator are
+   * separate route modules, so a module-scoped clock would have handed each of them its own
+   * copy — the simulator would advance a clock the agent never reads. The singleton lives on
+   * globalThis for exactly this reason.
+   */
+  it('changes what the agent does, through the routes the demo actually clicks', async () => {
+    await post({ toIso: '2026-08-21T21:00:00+05:30' });
+    const journeyId = await seedJourney();
+
+    let actions = await db
+      .select()
+      .from(recoveryActions)
+      .where(eq(recoveryActions.journeyId, journeyId));
+    expect(actions).toHaveLength(0); // 21:00 IST — outside the contact window
+
+    const advanced = await post({ toIso: '2026-08-22T09:00:00+05:30' });
+    expect(advanced.status).toBe(200);
+
+    await triggerRecovery();
+
+    actions = await db
+      .select()
+      .from(recoveryActions)
+      .where(eq(recoveryActions.journeyId, journeyId));
+    expect(actions).toHaveLength(1);
+    expect(actions[0].executedAt.startsWith('2026-08-22T09:00')).toBe(true);
+  });
+});


### PR DESCRIPTION
> ⚠️ **Fourth in the stack: #173 → #174 → #176 → this.** Based on #176 only so the migration numbering stays linear (this adds 0006). The change itself is independent of the model work.

## Description

`VirtualClock` was defined and referenced by nothing:

```
$ grep -rn "VirtualClock" src/ tests/
src/lib/utils/time.ts:27:export class VirtualClock implements Clock {
                                    ← the definition, and nothing else
```

Meanwhile `TASKS.md` marked task 8.1 ✅ and put it on the critical path, with the note: *"Without it, `smart_retry` and contact-hours deferral are undemonstrable — two of the four strategies and the best compliance evidence."* Both were still undemonstrable. No route advanced time, no simulator control existed, no `clock_advanced` event was ever written.

Closes #171

## What this adds

- **`src/lib/utils/demo-clock.ts`** — advance by an interval or to an absolute instant; promotes `SystemClock` to a `VirtualClock` on first use, and refuses to displace a clock a caller installed deliberately, so a test's pinned `FixedClock` keeps its pin.
- **`POST /api/simulator/clock`** (plus `GET` for current state). It sits under `/api/simulator/*` so it inherits that surface's guard — 404 on a production build unless `RECOVERAI_DEMO_MODE` is on. A deployment taking real Razorpay traffic must not be able to move time at all.
- **Simulator controls** — +1h, +24h, jump to 21:00 IST, jump to 09:00 next morning, showing the current simulated time and a `virtual` marker.

## The two rules that keep it a demo aid rather than a way to fake results

1. **Time only moves forward.** Rewinding past a fired attempt would re-open journeys whose scheduled outreach has already gone out, so the same attempt could replay and be counted twice. The way back to real time is a reseed — which deletes those rows first — so the seed route resets the clock.
2. **Every advance is audited.** A `clock_advanced` row records actor, from, to, and minutes skipped. An evaluator reading the timeline can see exactly where time jumped and confirm a stopping rule was *satisfied* rather than skipped over.

## Two things worth a reviewer's attention

**The clock singleton moved onto `globalThis`**, for the same reason the database connection lives there. A module-scoped `let` hands each route module its own copy under Next.js module evaluation — so the simulator would have advanced a clock the coordinator never reads, and the demo would have silently done nothing. `tests/demo-clock.test.ts` drives the *routes* (not just the lib) for exactly this reason; that test is the one that would have caught it.

**`audit_logs.journey_id` becomes nullable** (migration 0006). A clock advance belongs to no journey, and attaching it to an arbitrary one would put a false entry in that customer's timeline. Migration 0006 adds no column, so the legacy-adoption probe in `db/index.ts` reads the *constraint* (`PRAGMA table_info` → `notnull`) rather than the column list — otherwise every database would look pre-0006 forever and the table rebuild would replay on each boot.

## Verification

241/241 tests pass (10 new), typecheck, lint, `next build` clean (`/api/simulator/clock` in the route table).

The test that matters: a journey seeded at 21:00 IST dispatches nothing and logs a contact-hours deferral; after an advance to 09:00 the next morning, the same queue dispatches, and the action is stamped `2026-08-22T09:00`. The rule was satisfied, not bypassed.

## Demo script

`DEMO_SCRIPT.md`'s 1:45–2:45 scene now actually uses this: jump to 21:00, run the agent, show every outreach deferring with its rule logged, jump to 09:00, watch the same queue dispatch — then open the audit trail and show the `clock_advanced` rows alongside it.