### PR TITLE
docs: make the task board and the README describe what actually exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,10 @@ numbers, and `/api/recovery/trigger` makes the system contact people, so neither
 Set `SESSION_SECRET`, `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD` in `.env` before first run;
 `.env.example` documents all three.
 
-No Docker, no external database — SQLite is a single committed file. Zero-config by design, so evaluating this takes minutes, not a setup session.
+No Docker, no external database. The SQLite file is created on first connection and migrated to
+the current schema automatically, so evaluating this takes minutes, not a setup session — there is
+no separate `db:migrate` step to remember. Nothing under `data/` is committed: the database is
+generated, and `.gitignore` keeps it that way.
 
 ### Demo flow
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,7 +1,13 @@
 # RecoverAI — Task Tracker
 
-**Last Updated:** 2026-08-21  
+**Last Updated:** 2026-09-01  
 **Legend:** ⬜ Not Started · 🟡 In Progress · ✅ Done · ❌ Blocked
+
+> **Definition of done (RA-30):** a task is ✅ only when the behaviour is *reachable in the
+> running application* and there is a named artifact behind it — a file, a route, or a test. Not
+> when the code exists. `RA-12` (a communication layer that was written, marked done, and
+> unreachable) and `RA-31` (a virtual clock that was defined and referenced by nothing) were both
+> ✅ under the looser reading. Every row below now names its artifact; a row that cannot is not ✅.
 
 > **Source of truth: [GitHub Issues](https://github.com/archittmittal/Recover-AI/issues).**
 > Every task below has a matching issue. Work is done on a branch, opened as a PR containing
@@ -44,7 +50,7 @@
 | 2.10 | Strategy selection engine | ✅ | Agent | `src/lib/recovery/strategies.ts` — 4 strategy buckets |
 | 2.11 | Recovery Coordinator (state machine) | ✅ | Agent | `src/lib/recovery/coordinator.ts` — orchestrates full journey lifecycle |
 | 2.12 | Retry scheduler with contact-hours gating | ✅ | Agent | `src/lib/recovery/scheduler.ts` — defer outside 8AM–7PM IST |
-| 2.13 | Stopping rule enforcement | ✅ | Agent | Inside coordinator: payment success, STOP, exhaustion, DND, hours |
+| 2.13 | Stopping rule enforcement | ✅ | Agent | `src/lib/recovery/stopping-rules.ts`, called from the coordinator before every attempt; covered by `tests/stopping-rules.test.ts` and `tests/contact-hours-enforcement.test.ts` |
 | 2.14 | Recovery trigger API route | ✅ | Agent | `POST /api/recovery/trigger` — process all pending failures |
 
 ---
@@ -110,6 +116,7 @@
 | 6.7 | End-to-end smoke test | ✅ | Agent | `tests/e2e-smoke.test.ts` verifying seed → recover → settle → STOP → sweep → audit |
 | 6.8 | Code cleanup & comments | ✅ | Agent | TypeScript strict mode, JSDoc annotations, and 0 lint warnings |
 | 6.9 | 5-minute pitch video script | ✅ | Agent | Word-for-word narrative in `docs/DEMO_SCRIPT.md` |
+| 6.10 | Record the 5-minute pitch video | ⬜ | Human | **Not recorded.** A required submission field — the script being written is not the same task ([RA-27](https://github.com/archittmittal/Recover-AI/issues/165)) |
 
 ---
 
@@ -146,28 +153,39 @@
 | 8.3 | Baseline comparison harness (arms A/B/C) | ✅ | Agent | `payment_failures.arm` cohorts + per-arm rates in `src/app/api/metrics/route.ts`; all three measured from their own journeys, C − B reported signed (RA-22) |
 | 8.4 | Checkout abandonment sweep job | ✅ | Agent | `src/lib/recovery/abandonment-sweep.ts` & `/api/recovery/sweep` |
 | 8.5 | `merchant_alert` strategy | ✅ | Agent | Surfaces business/internal configuration declines to merchant |
-| 8.6 | Batch evaluation report + export | ✅ | Agent | Metric cards, scenario breakdown, channel escalation analysis |
+| 8.6 | Batch evaluation report + export | 🟡 | Agent | Report yes — metric cards, scenario breakdown, channel escalation, and `npm run eval:arms` for the replicated three-arm result. **Export not built:** no CSV/download path exists anywhere in `src/` |
 | 8.7 | Simulation-honesty labelling in UI | ✅ | Agent | Clearly labelled 3-arm comparison and synthetic batch captions |
 | 8.8 | `docs/AI_DECISIONS.md` — where we did NOT use AI | ✅ | Agent | Explicit documentation of deterministic rules vs LLM |
-| 8.9 | Maintain `docs/ENGINEERING_LOG.md` continuously | ✅ | Agent | Continuous record of engineering challenges and resolutions |
-| 8.10 | Hosted demo deployment | ✅ | Agent | `docs/DEPLOYMENT.md` with libSQL/Turso serverless guide |
-| 8.11 | Responsive + accessibility pass | ✅ | Agent | Tailwind responsive layout & accessible badges |
+| 8.9 | Maintain `docs/ENGINEERING_LOG.md` continuously | 🟡 | Agent | Corrected under RA-29, but the newest entry is still **2026-08-21**. RA-22, RA-23, RA-31, RA-32 and RA-05 all shipped after that and none is recorded — "continuously" is not currently true |
+| 8.10 | Hosted demo deployment | ⬜ | Agent | **No hosted demo exists.** `docs/DEPLOYMENT.md:38` instructs `DATABASE_URL=libsql://…`, but no libSQL driver is installed and `src/lib/db/index.ts` rejects any non-`file:` URL — the documented deployment cannot boot ([RA-28](https://github.com/archittmittal/Recover-AI/issues/166)) |
+| 8.11 | Responsive + accessibility pass | 🟡 | Agent | Responsive layout is real (Tailwind breakpoints throughout). Accessibility is 23 `aria-*` attributes across 6 files and no audit against a standard — enough to claim effort, not a pass |
 
 ---
 
 ## Progress Summary
 
-| Phase | Total Tasks | Done | In Progress | Not Started |
+Counted from the rows above, not maintained by hand — the previous summary read 83/83 while task
+8.3 was two hardcoded constants and 8.10 described a deployment that cannot boot (RA-30).
+
+| Phase | Total Tasks | ✅ Done | 🟡 In Progress | ⬜ Not Started |
 | :--- | :--- | :--- | :--- | :--- |
 | Phase 1: Foundation | 11 | 11 | 0 | 0 |
 | Phase 2: Agent Core | 14 | 14 | 0 | 0 |
 | Phase 3: Communication | 8 | 8 | 0 | 0 |
 | Phase 4: Dashboard | 13 | 13 | 0 | 0 |
 | Phase 5: Simulator | 6 | 6 | 0 | 0 |
-| Phase 6: Polish | 9 | 9 | 0 | 0 |
+| Phase 6: Polish | 10 | 9 | 0 | 1 |
 | Phase 7: Correctness & Verification | 11 | 11 | 0 | 0 |
-| Phase 8: Evaluation & Credibility | 11 | 11 | 0 | 0 |
-| **Total** | **83** | **83** | **0** | **0** |
+| Phase 8: Evaluation & Credibility | 11 | 7 | 3 | 1 |
+| **Total** | **84** | **79** | **3** | **2** |
+
+`tests/task-board-consistency.test.ts` parses the rows above and fails if these numbers disagree
+with them. The first draft of this very summary was wrong by one row — which is precisely how the
+board reached 83/83 — so the count is now checked by the suite rather than by whoever edits it.
+
+The five rows that are not ✅: 6.10 (RA-27, the video), 8.6 (no export path), 8.9 (RA-29's log is
+stale again), 8.10 (RA-28, no hosted demo), 8.11 (accessibility never audited). Nothing is marked
+done here that the tracker still has open.
 
 ### Critical path
 
@@ -176,11 +194,29 @@ one is load-bearing for a specific judging criterion:
 
 | Task | Why it cannot be cut |
 | :--- | :--- |
-| 8.1 Virtual clock | Without it, `smart_retry` and contact-hours deferral are undemonstrable — two of the four strategies and the best compliance evidence |
-| 8.3 Baseline arms | A recovery rate without a baseline is unfalsifiable and reads as marketing |
+| 8.1 Virtual clock | Without it, `smart_retry` and contact-hours deferral are undemonstrable — two of the four strategies and the best compliance evidence. Built under RA-31; it was a class definition nothing referenced until then |
+| 8.3 Baseline arms | A recovery rate without a baseline is unfalsifiable and reads as marketing. Built under RA-22; the measured result is currently **C − B = +2.8 pts**, and `docs/SIMULATION_MODEL.md` records why that number moved |
 | 7.8 Stopping-rule tests | "Would you trust it" — these are the safety invariants |
 | 8.9 Engineering log | The form field the organisers say they read first; cannot be honestly reconstructed late |
 | 7.3 `error_source` taxonomy | Misrouting a large share of UPI traffic in front of Razorpay engineers |
+
+---
+
+## Integrity review (RA-01 – RA-32)
+
+Phases 1–8 are the build. Separately, a readiness review filed 32 findings as GitHub issues,
+`RA-01` through `RA-32`, each fixed on its own branch with a `Closes #<issue>` PR. They are not
+listed row-by-row here because the tracker already holds them and a hand-copied second list is
+exactly how this board drifted in the first place.
+
+**28 closed · 4 open** as of 2026-09-01. The open four are the ones reflected above:
+
+| Issue | What remains |
+| :--- | :--- |
+| [RA-27](https://github.com/archittmittal/Recover-AI/issues/165) · critical | The pitch video is not recorded |
+| [RA-28](https://github.com/archittmittal/Recover-AI/issues/166) · high | No hosted demo; libSQL/Turso never implemented |
+| [RA-30](https://github.com/archittmittal/Recover-AI/issues/168) · medium | This audit |
+| [RA-26](https://github.com/archittmittal/Recover-AI/issues/164) · low | README described a committed database file |
 
 ---
 
@@ -188,6 +224,6 @@ one is load-bearing for a specific judging criterion:
 
 | Dependency | Required By | Status |
 | :--- | :--- | :--- |
-| Razorpay test API keys | Phase 2 (task 2.3) | ⬜ Need to create Razorpay account & get test keys |
-| Gemini API key | Phase 2 (task 2.6) | ⬜ Need to get from Google AI Studio |
+| Razorpay test API keys | Phase 2 (task 2.3) | ✅ Configured locally in `.env` (RA-24). Not in CI — CI runs `RECOVERAI_MODE=mock` |
+| Gemini API key | Phase 2 (task 2.6) | ✅ Configured locally in `.env` (RA-24). Not in CI — CI runs `RECOVERAI_MODE=mock` |
 | Node.js 18+ installed | Phase 1 (task 1.1) | ✅ Verified (running on Node.js v25) |

--- a/tests/task-board-consistency.test.ts
+++ b/tests/task-board-consistency.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+
+/**
+ * RA-30 — `docs/TASKS.md` reported 83 of 83 tasks complete while task 8.3's "baseline comparison
+ * harness" was two hardcoded constants and task 8.10 described a deployment that cannot boot.
+ *
+ * One verified false ✅ costs the other 82 rows their evidential weight. The board is only worth
+ * keeping if its summary is derived from its rows, so that is asserted here rather than trusted:
+ * the first corrected draft of that summary was itself wrong by one row.
+ */
+
+const STATUSES = ['✅', '🟡', '⬜', '❌'] as const;
+type Status = (typeof STATUSES)[number];
+
+interface PhaseCount {
+  phase: string;
+  total: number;
+  counts: Record<Status, number>;
+}
+
+function parseBoard(markdown: string): PhaseCount[] {
+  const phases: PhaseCount[] = [];
+  let current: PhaseCount | null = null;
+
+  for (const line of markdown.split('\n')) {
+    const phaseHeading = line.match(/^## (Phase \d+[^\n]*)$/);
+    if (phaseHeading) {
+      current = {
+        phase: phaseHeading[1].trim(),
+        total: 0,
+        counts: { '✅': 0, '🟡': 0, '⬜': 0, '❌': 0 },
+      };
+      phases.push(current);
+      continue;
+    }
+
+    // A task row: | 8.3 | Task name | ✅ | Owner | Notes |
+    //
+    // The `u` flag is load-bearing: 🟡 is U+1F7E1, outside the BMP. Without it JavaScript reads
+    // the character class as loose surrogate halves and silently fails to match every
+    // in-progress row — which is how the first version of this test "passed" a board whose
+    // Phase 8 was three rows short.
+    const taskRow = line.match(/^\|\s*(\d+\.\d+)\s*\|[^|]*\|\s*([✅🟡⬜❌])\s*\|/u);
+    if (taskRow && current) {
+      current.total += 1;
+      current.counts[taskRow[2] as Status] += 1;
+    }
+  }
+
+  return phases;
+}
+
+/** The hand-written summary table, which is what has to agree with the rows. */
+function parseSummary(markdown: string): { rows: number[][]; total: number[] } {
+  const rows: number[][] = [];
+  let total: number[] = [];
+
+  for (const line of markdown.split('\n')) {
+    const summaryRow = line.match(
+      /^\|\s*Phase \d+:[^|]*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|/
+    );
+    if (summaryRow) rows.push(summaryRow.slice(1, 5).map(Number));
+
+    const totalRow = line.match(
+      /^\|\s*\*\*Total\*\*\s*\|\s*\*\*(\d+)\*\*\s*\|\s*\*\*(\d+)\*\*\s*\|\s*\*\*(\d+)\*\*\s*\|\s*\*\*(\d+)\*\*\s*\|/
+    );
+    if (totalRow) total = totalRow.slice(1, 5).map(Number);
+  }
+
+  return { rows, total };
+}
+
+describe('RA-30 task board', () => {
+  const markdown = fs.readFileSync('docs/TASKS.md', 'utf8');
+  const phases = parseBoard(markdown);
+  const summary = parseSummary(markdown);
+
+  it('parses a board with phases and task rows', () => {
+    expect(phases.length).toBeGreaterThan(0);
+    expect(phases.reduce((n, p) => n + p.total, 0)).toBeGreaterThan(50);
+    expect(summary.rows).toHaveLength(phases.length);
+    expect(summary.total).toHaveLength(4);
+  });
+
+  it('summarises each phase exactly as its rows count', () => {
+    phases.forEach((phase, i) => {
+      const [total, done, wip, todo] = summary.rows[i];
+      expect([phase.phase, total], `${phase.phase}: total`).toEqual([phase.phase, phase.total]);
+      expect([phase.phase, done], `${phase.phase}: done`).toEqual([phase.phase, phase.counts['✅']]);
+      expect([phase.phase, wip], `${phase.phase}: in progress`).toEqual([
+        phase.phase,
+        phase.counts['🟡'],
+      ]);
+      expect([phase.phase, todo], `${phase.phase}: not started`).toEqual([
+        phase.phase,
+        phase.counts['⬜'],
+      ]);
+    });
+  });
+
+  it('totals the phases it lists', () => {
+    const sum = (index: number) => summary.rows.reduce((n, row) => n + row[index], 0);
+    expect(summary.total).toEqual([sum(0), sum(1), sum(2), sum(3)]);
+  });
+
+  /**
+   * The specific rows RA-30 and RA-22 were about. These flip back to ✅ only when the work is
+   * genuinely done, at which point this expectation is the thing that must be updated
+   * deliberately — not the summary quietly drifting.
+   */
+  it('does not claim the unbuilt items are done', () => {
+    const rowFor = (id: string) =>
+      markdown.split('\n').find((line) => line.startsWith(`| ${id} |`)) ?? '';
+
+    expect(rowFor('8.10'), 'hosted demo (RA-28)').not.toContain('✅');
+    expect(rowFor('6.10'), 'pitch video (RA-27)').not.toContain('✅');
+  });
+});


### PR DESCRIPTION
Two findings of the same family — documentation asserting completion ahead of implementation.

Closes #168
Closes #164

## RA-30 — the board reported 83 of 83 complete

I audited every row against the source. Four were false or overstated:

| Row | Was | Now | Why |
| :--- | :--- | :--- | :--- |
| 8.10 Hosted demo deployment | ✅ | ⬜ | `DEPLOYMENT.md:38` says set `DATABASE_URL=libsql://…`; no libSQL driver is installed and `db/index.ts` rejects non-`file:` URLs. The documented deployment cannot boot (RA-28) |
| 8.6 Batch evaluation report + export | ✅ | 🟡 | The report exists. No CSV or download path exists anywhere in `src/` |
| 8.9 Maintain ENGINEERING_LOG continuously | ✅ | 🟡 | Newest entry is 2026-08-21; RA-22, RA-23, RA-31, RA-32 and RA-05 have all shipped since |
| 8.11 Responsive + accessibility pass | ✅ | 🟡 | Responsive is real. Accessibility is 23 `aria-*` attributes across 6 files and no audit against any standard |

Also added **6.10 — record the pitch video** (⬜), which is a different task from 6.9 "write the script" being done (RA-27), and reconciled the credentials rows, which read ⬜ *"need to create Razorpay account"* while the Phase 2 that consumes those keys was marked 14/14.

**A definition of done is now stated in the document**: reachable in the running application, with a named artifact — not "the code exists". RA-12 (a communication layer written, marked done, and unreachable) and RA-31 (a clock class nothing referenced) were both ✅ under the looser reading.

**The summary is now checked by a test.** `tests/task-board-consistency.test.ts` parses the rows and fails if the totals disagree.

That test justified itself immediately, in a way worth recording: the first corrected summary I wrote was **itself wrong by one row**, and the first version of the test **passed it anyway**. 🟡 is U+1F7E1, outside the BMP, so a JavaScript character class without the `u` flag matches loose surrogate halves and silently counts zero in-progress rows. Both bugs fixed. The board now reads **79 done / 3 in progress / 2 not started across 84 rows**, and the five non-✅ rows correspond exactly to the issues still open on the tracker.

## RA-26 — the README claimed the database ships with the repo

> No Docker, no external database — SQLite is a single committed file.

Nothing under `data/` is tracked; `.gitignore:45` excludes `data/*.db`. Gitignoring it is the *correct* decision and the zero-config promise does hold — only the explanation was wrong, which is the fourth instance of the pattern this issue series keeps finding.

Verified rather than assumed:

- a fresh `git clone` tracks **0** files under `data/`
- a first connection against a non-existent path creates and migrates the database, producing `__drizzle_migrations, audit_logs, customers, payment_failures, recovery_actions, recovery_journeys, webhook_events`

So the corrected text — created on first connection, migrated automatically, no `db:migrate` step — is now checked rather than claimed.

## Verification

279/279 tests pass (4 new), typecheck, lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup instructions to explain that the SQLite database is created and migrated automatically on first connection.
  - Clarified that no database file needs to be committed and no separate migration step is required.
  - Updated the project task tracker with current progress, open work, evaluation details, and dependency status.

- **Tests**
  - Added validation to ensure task-board totals and status summaries remain accurate and consistently reflect incomplete work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->