### PR TITLE
feat(db): support libSQL/Turso so the documented deployment can actually boot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,17 @@ GEMINI_API_KEY=XXXXXXXXXXXXXXXXXXXXXXXX
 # would let the model change under a recorded demo. Override here if this one is retired.
 GEMINI_MODEL=gemini-3.6-flash
 
-# Database Configuration (SQLite)
+# Database. The driver is chosen from the scheme (RA-28):
+#   file:      → better-sqlite3, created and migrated on first connection (local development)
+#   libsql://  → Turso, for a serverless deployment where a local file would be lost
+#   https://   → Turso over HTTP
+# Any other scheme fails at startup rather than being treated as a filename.
 DATABASE_URL=file:./data/recoverai.db
+
+# Required only when DATABASE_URL is remote: `turso db tokens create <database>`.
+# Remote databases are NOT migrated on boot — run `npm run db:migrate` once at deploy time,
+# then `npm run db:verify` to confirm. See docs/DEPLOYMENT.md.
+# DATABASE_AUTH_TOKEN=
 
 # Whether this process talks to real Razorpay and Gemini APIs.
 #   mock (default) — no outbound calls; payment links and LLM copy are simulated.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -10,9 +10,14 @@ This guide covers deploying **RecoverAI** to modern serverless and containerized
 | :--- | :--- | :--- |
 | `RAZORPAY_KEY_ID` | Razorpay Key ID (from Razorpay Dashboard > Settings > API Keys) | `rzp_test_...` or `rzp_live_...` |
 | `RAZORPAY_KEY_SECRET` | Razorpay Key Secret | `sec_...` |
-| `RAZORPAY_WEBHOOK_SECRET` | Secret configured on Razorpay Webhook settings | `wh_sec_...` |
-| `GEMINI_API_KEY` | Google Gemini API Key (from Google AI Studio) | `AIzaSy...` |
-| `DATABASE_URL` | SQLite file path or remote Turso/libSQL connection URL | `file:./data/recoverai.db` |
+| `RAZORPAY_WEBHOOK_SECRET` | A secret **you choose** and enter in both places: the Razorpay webhook form and this variable. Razorpay does not issue it and it has no fixed format | any high-entropy string |
+| `GEMINI_API_KEY` | Google Gemini API Key (from Google AI Studio) | `AIza...` |
+| `DATABASE_URL` | `file:` for a local SQLite file, `libsql://` or `https://` for Turso | `file:./data/recoverai.db` |
+| `DATABASE_AUTH_TOKEN` | Turso token. **Required** whenever `DATABASE_URL` is remote; startup fails without it | `turso db tokens create <db>` |
+| `SESSION_SECRET` | Signing key for the dashboard session cookie. Every page and API route except the webhook is behind it (RA-05) | 32+ random bytes |
+| `DASHBOARD_USERNAME` / `DASHBOARD_PASSWORD` | Dashboard login | — |
+| `RECOVERAI_MODE` | `mock` (no outbound calls) or `live` (real Razorpay/Gemini) | `mock` |
+| `RECOVERAI_DEMO_MODE` | `true` exposes `/api/simulator/*` on a production build. **Leave unset unless this deployment is a throwaway demo** — those routes are unauthenticated and `/api/simulator/seed` truncates every table | unset |
 | `NEXT_PUBLIC_APP_URL` | Production public URL of the deployment | `https://recoverai.yourdomain.com` |
 
 ---
@@ -34,9 +39,43 @@ sqlite.pragma('journal_mode = WAL');
   ```
 
 ### Option B: Serverless Deployment (Vercel + Turso libSQL)
-- Create a free database on [Turso](https://turso.tech).
-- Set `DATABASE_URL=libsql://your-db-name.turso.io` and `DATABASE_AUTH_TOKEN=your-token`.
-- RecoverAI automatically handles schema migrations on boot.
+
+The driver is chosen from the `DATABASE_URL` scheme (`src/lib/db/index.ts`): `file:` uses
+`better-sqlite3`, `libsql://` and `https://` use `@libsql/client`. Anything else fails at startup
+with a message naming the two it accepts, rather than being silently treated as a filename.
+
+**Migrations are not applied on boot for a remote database.** On a serverless host every cold
+start would race every other cold start to migrate the one shared database. Apply them once, at
+deploy time:
+
+```bash
+# 1. Create the database and a token
+turso db create recoverai
+turso db show recoverai --url          # → libsql://recoverai-<org>.turso.io
+turso db tokens create recoverai       # → the DATABASE_AUTH_TOKEN value
+
+# 2. Apply the migrations from your machine (drizzle.config.ts switches to the
+#    Turso dialect automatically when DATABASE_URL is remote)
+DATABASE_URL=libsql://recoverai-<org>.turso.io \
+DATABASE_AUTH_TOKEN=<token> \
+  npm run db:migrate
+
+# 3. Confirm the schema landed, and optionally seed the demo batch
+DATABASE_URL=libsql://recoverai-<org>.turso.io \
+DATABASE_AUTH_TOKEN=<token> \
+  npm run db:verify                    # add SEED=1 to populate the 150-failure batch
+```
+
+`npm run db:verify` reports how many migrations are applied and which tables exist, so a
+forgotten migrate step surfaces as a sentence naming the fix instead of `no such table:
+customers` at the first dashboard request.
+
+**Then deploy.** Set every variable from §1 in the Vercel project. Leave `RECOVERAI_DEMO_MODE`
+unset unless the deployment is a throwaway demo — with it on, anyone who finds the URL can
+truncate the database.
+
+Local development is unchanged: no `DATABASE_URL` at all still means `file:./data/recoverai.db`,
+created and migrated on first connection with no separate step.
 
 ---
 
@@ -51,13 +90,15 @@ To receive live transaction events and trigger autonomous recovery:
    https://recoverai.yourdomain.com/api/webhooks/razorpay
    ```
 4. Enter a strong secret and save it to your `RAZORPAY_WEBHOOK_SECRET` environment variable.
-5. Subscribe to the following **Active Events**:
-   - `payment.failed` (triggers failure classification and dunning initiation)
-   - `payment.captured` (triggers payment resolution and stops outreach)
-   - `subscription.pending` (triggers mandate recovery)
-   - `subscription.halted` (triggers invoice reminders)
-   - `payment_link.paid` (resolves recovery journeys)
-6. Save and test using Razorpay's **Send Test Webhook** button.
+5. Subscribe to **`payment.failed`** only.
+
+   That is the sole event the handler acts on — `payload.event` is tested once, at
+   `src/app/api/webhooks/razorpay/route.ts:115`. Any other subscribed event is verified,
+   recorded in `webhook_events`, marked `processed`, and has **no effect on any journey**:
+   Razorpay's delivery log shows green while nothing happens. In particular `payment_link.paid`
+   does *not* resolve a recovery journey today, so a customer paying through a recovery link is
+   not reflected on the dashboard by this route.
+6. Trigger a delivery from the dashboard to confirm the wiring end to end.
 
 ---
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,10 +1,31 @@
 import { defineConfig } from 'drizzle-kit';
 
-export default defineConfig({
-  schema: './src/lib/db/schema.ts',
-  out: './src/lib/db/migrations',
-  dialect: 'sqlite',
-  dbCredentials: {
-    url: (process.env.DATABASE_URL || 'file:./data/recoverai.db').replace(/^file:/, ''),
-  },
-});
+/**
+ * One config, two targets (RA-28).
+ *
+ * `file:` keeps the SQLite dialect used to generate every existing migration; a `libsql://` or
+ * `https://` URL switches to the Turso dialect so `drizzle-kit migrate` can apply those same
+ * migrations to the deployed database. The scheme is the only switch — there is no second config
+ * file to forget to update.
+ */
+const url = process.env.DATABASE_URL || 'file:./data/recoverai.db';
+const isRemote = url.startsWith('libsql://') || url.startsWith('https://');
+
+export default defineConfig(
+  isRemote
+    ? {
+        schema: './src/lib/db/schema.ts',
+        out: './src/lib/db/migrations',
+        dialect: 'turso',
+        dbCredentials: {
+          url,
+          authToken: process.env.DATABASE_AUTH_TOKEN,
+        },
+      }
+    : {
+        schema: './src/lib/db/schema.ts',
+        out: './src/lib/db/migrations',
+        dialect: 'sqlite',
+        dbCredentials: { url: url.replace(/^file:/, '') },
+      }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@base-ui/react": "^1.7.0",
         "@google/generative-ai": "^0.24.1",
+        "@libsql/client": "^0.17.4",
         "better-sqlite3": "^13.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2409,6 +2410,165 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@libsql/client": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.4.tgz",
+      "integrity": "sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@libsql/core": "^0.17.4",
+        "@libsql/hrana-client": "^0.10.0",
+        "js-base64": "^3.7.5",
+        "libsql": "^0.5.28",
+        "promise-limit": "^2.7.0"
+      }
+    },
+    "node_modules/@libsql/core": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.17.4.tgz",
+      "integrity": "sha512-LqF9gIvnJ38nmAH1y/ChizHqDO/MO1wLgA96XrraulEEbqXxLjleSH92YWTolbuJKgPUmGu4aJk9W3UnAcxLOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "js-base64": "^3.7.5"
+      }
+    },
+    "node_modules/@libsql/darwin-arm64": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.5.29.tgz",
+      "integrity": "sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/darwin-x64": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.5.29.tgz",
+      "integrity": "sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/hrana-client": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.10.0.tgz",
+      "integrity": "sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@libsql/isomorphic-ws": "^0.1.5",
+        "js-base64": "^3.7.5"
+      }
+    },
+    "node_modules/@libsql/isomorphic-ws": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-ws/-/isomorphic-ws-0.1.5.tgz",
+      "integrity": "sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ws": "^8.5.4",
+        "ws": "^8.13.0"
+      }
+    },
+    "node_modules/@libsql/linux-arm-gnueabihf": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.5.29.tgz",
+      "integrity": "sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm-musleabihf": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm-musleabihf/-/linux-arm-musleabihf-0.5.29.tgz",
+      "integrity": "sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-gnu": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.5.29.tgz",
+      "integrity": "sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-musl": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.5.29.tgz",
+      "integrity": "sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-gnu": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.5.29.tgz",
+      "integrity": "sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-musl": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.5.29.tgz",
+      "integrity": "sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/win32-x64-msvc": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.5.29.tgz",
+      "integrity": "sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
@@ -2490,6 +2650,12 @@
         "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
         "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
       }
+    },
+    "node_modules/@neon-rs/load": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
+      "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
+      "license": "MIT"
     },
     "node_modules/@next/env": {
       "version": "16.3.3",
@@ -3591,7 +3757,6 @@
       "version": "26.4.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
       "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -3637,6 +3802,15 @@
       "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.67.0",
@@ -8234,6 +8408,12 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-base64": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.3.tgz",
+      "integrity": "sha512-uwYQp+VJ38FVvtim6qNbit6e9uT6dwWQ4Y1+H9TxhW5hcHjpHwoxlR0nMpqUmIFOmu4VqMxwdJA88gIVuZJQ/g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
@@ -8374,6 +8554,47 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/libsql": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.5.29.tgz",
+      "integrity": "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==",
+      "cpu": [
+        "x64",
+        "arm64",
+        "wasm32",
+        "arm"
+      ],
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "@neon-rs/load": "^0.0.4",
+        "detect-libc": "2.0.2"
+      },
+      "optionalDependencies": {
+        "@libsql/darwin-arm64": "0.5.29",
+        "@libsql/darwin-x64": "0.5.29",
+        "@libsql/linux-arm-gnueabihf": "0.5.29",
+        "@libsql/linux-arm-musleabihf": "0.5.29",
+        "@libsql/linux-arm64-gnu": "0.5.29",
+        "@libsql/linux-arm64-musl": "0.5.29",
+        "@libsql/linux-x64-gnu": "0.5.29",
+        "@libsql/linux-x64-musl": "0.5.29",
+        "@libsql/win32-x64-msvc": "0.5.29"
+      }
+    },
+    "node_modules/libsql/node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lightningcss": {
@@ -9831,6 +10052,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
+      "license": "ISC"
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -12326,7 +12553,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -13079,6 +13305,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:check": "drizzle-kit check",
-    "eval:arms": "vitest run --config vitest.eval.mts"
+    "eval:arms": "vitest run --config vitest.eval.mts scripts/evaluate-arms.eval.ts",
+    "db:verify": "vitest run --config vitest.eval.mts scripts/deploy-check.eval.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",
     "@google/generative-ai": "^0.24.1",
+    "@libsql/client": "^0.17.4",
     "better-sqlite3": "^13.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/scripts/deploy-check.eval.ts
+++ b/scripts/deploy-check.eval.ts
@@ -1,0 +1,62 @@
+/**
+ * Deployment verification for a remote libSQL/Turso database (RA-28).
+ *
+ * Usage:
+ *   DATABASE_URL=libsql://… DATABASE_AUTH_TOKEN=… npm run db:verify
+ *   DATABASE_URL=libsql://… DATABASE_AUTH_TOKEN=… SEED=1 npm run db:verify
+ *
+ * Answers the two questions a deploy actually fails on — "did the migrations run?" and "is there
+ * any data?" — because both surface otherwise as an unexplained `no such table: customers` at the
+ * first dashboard request, several minutes after the deploy appeared to succeed.
+ *
+ * Runs under Vitest for the same reason `evaluate-arms.eval.ts` does: the application's modules
+ * use the `@/` path alias and extensionless imports that only the project toolchain resolves.
+ */
+
+import { it } from 'vitest';
+
+it('verifies the deployed database', async () => {
+  const url = process.env.DATABASE_URL || '';
+  if (!url.startsWith('libsql://') && !url.startsWith('https://')) {
+    throw new Error(
+      `Set DATABASE_URL to your Turso database first. Got "${url || '(unset)'}".\n` +
+        'This check is for a deployed database; local files migrate themselves on connect.'
+    );
+  }
+
+  const { verifyRemoteSchema } = await import('../src/lib/db');
+  const { applied, tables } = await verifyRemoteSchema();
+
+  console.log(`\nmigrations applied: ${applied}`);
+  console.log(`tables: ${tables.join(', ')}\n`);
+
+  const expected = [
+    'customers',
+    'payment_failures',
+    'recovery_journeys',
+    'recovery_actions',
+    'audit_logs',
+    'webhook_events',
+  ];
+  const missing = expected.filter((t) => !tables.includes(t));
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing tables: ${missing.join(', ')}. Run \`npm run db:migrate\` against this database.`
+    );
+  }
+
+  const { db } = await import('../src/lib/db');
+  const { customers } = await import('../src/lib/db/schema');
+  const rows = await db.select().from(customers);
+  console.log(`customers currently in the deployed database: ${rows.length}`);
+
+  if (process.env.SEED === '1') {
+    const { seedDatabase } = await import('../src/lib/db/seed');
+    const count = await seedDatabase();
+    console.log(`seeded ${count} failures across the three experiment arms`);
+  } else if (rows.length === 0) {
+    console.log('empty — re-run with SEED=1 to populate the demo batch');
+  }
+
+  console.log('\n✓ deployed database is migrated and reachable\n');
+}, 10 * 60 * 1000);

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,13 +1,29 @@
 import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { drizzle as drizzleLibsql, LibSQLDatabase } from 'drizzle-orm/libsql';
+import { createClient } from '@libsql/client';
+import { BaseSQLiteDatabase } from 'drizzle-orm/sqlite-core';
 import Database from 'better-sqlite3';
 import * as schema from './schema';
 import path from 'path';
 import fs from 'fs';
 
+/**
+ * Two drivers, chosen by URL scheme (RA-28).
+ *
+ * `better-sqlite3` writes to a local file, which is the right thing for development and
+ * completely wrong for a serverless deployment: the filesystem is ephemeral and per-instance, so
+ * a Vercel deploy would appear to work and then silently lose data mid-demo. `libsql:`/`https:`
+ * URLs therefore go to a Turso client instead.
+ *
+ * Local behaviour is deliberately untouched — same driver, same WAL pragma, same
+ * migrate-on-connect, same legacy adoption — so the zero-config story still holds.
+ */
+type SchemaDatabase = BaseSQLiteDatabase<'sync' | 'async', unknown, typeof schema>;
+
 const globalForDb = globalThis as unknown as {
   sqlite: Database.Database | undefined;
-  db: BetterSQLite3Database<typeof schema> | undefined;
+  db: SchemaDatabase | undefined;
 };
 
 const MIGRATIONS_FOLDER = path.join(process.cwd(), 'src/lib/db/migrations');
@@ -151,18 +167,24 @@ function stampLegacyGeneration(sqlite: Database.Database, when: number): void {
   );
 }
 
-function getOrCreateDb(): BetterSQLite3Database<typeof schema> {
-  if (globalForDb.db) {
-    return globalForDb.db;
-  }
+/** How a DATABASE_URL is served. Exported so tests and the deploy check can assert on it. */
+export type DbDriver = 'better-sqlite3' | 'libsql';
 
-  const dbUrl = process.env.DATABASE_URL || 'file:./data/recoverai.db';
-  if (!dbUrl.startsWith('file:')) {
-    throw new Error(
-      `[db] Unsupported DATABASE_URL scheme: "${dbUrl.split(':')[0]}:". ` +
-        `This build targets better-sqlite3 and accepts only "file:" URLs.`
-    );
-  }
+export function resolveDriver(dbUrl: string): DbDriver {
+  if (dbUrl.startsWith('file:')) return 'better-sqlite3';
+  if (dbUrl.startsWith('libsql://') || dbUrl.startsWith('https://')) return 'libsql';
+
+  // Loudly, rather than mangling it into a filename. The old code stripped a `file:` prefix that
+  // was not there and handed `libsql://…` to better-sqlite3, which dutifully created a local
+  // file with that name — the documented Turso deployment "worked" and wrote to nowhere.
+  throw new Error(
+    `[db] Unsupported DATABASE_URL scheme: "${dbUrl.split(':')[0]}:". ` +
+      `Use "file:" for a local SQLite file, or "libsql://" / "https://" for Turso.`
+  );
+}
+
+/** Local file database: unchanged from before RA-28, including migrate-on-connect. */
+function createLocalDb(dbUrl: string): SchemaDatabase {
   const dbPath = dbUrl.replace(/^file:/, '');
   const dbDir = path.dirname(dbPath);
 
@@ -180,7 +202,7 @@ function getOrCreateDb(): BetterSQLite3Database<typeof schema> {
     stampLegacyGeneration(sqlite, legacyGeneration);
   }
 
-  const dbInstance = drizzle(sqlite, { schema });
+  const dbInstance: BetterSQLite3Database<typeof schema> = drizzle(sqlite, { schema });
 
   // Migrations are the single source of schema truth. Applying them on connect keeps the
   // zero-config promise (no separate `db:migrate` step) while letting an existing database
@@ -188,12 +210,78 @@ function getOrCreateDb(): BetterSQLite3Database<typeof schema> {
   migrate(dbInstance, { migrationsFolder: MIGRATIONS_FOLDER });
 
   globalForDb.sqlite = sqlite;
-  globalForDb.db = dbInstance;
-
   return dbInstance;
 }
 
-export const db = new Proxy({} as BetterSQLite3Database<typeof schema>, {
+/**
+ * Remote libSQL/Turso database.
+ *
+ * Migrations are NOT applied here. On a serverless host every cold start would race every other
+ * cold start to run them, against a database they all share — and a migration is not something to
+ * attempt concurrently from an unknown number of instances. `npm run db:migrate` applies them
+ * once at deploy time instead; `docs/DEPLOYMENT.md` documents that step, and
+ * `verifyRemoteSchema()` below turns a forgotten one into a clear error rather than a confusing
+ * "no such table" at the first request.
+ */
+function createRemoteDb(dbUrl: string): SchemaDatabase {
+  const authToken = process.env.DATABASE_AUTH_TOKEN;
+  if (!authToken) {
+    throw new Error(
+      '[db] DATABASE_URL points at a remote libSQL database but DATABASE_AUTH_TOKEN is unset. ' +
+        'Create a token with `turso db tokens create <database>`.'
+    );
+  }
+
+  const client = createClient({ url: dbUrl, authToken });
+  const dbInstance: LibSQLDatabase<typeof schema> = drizzleLibsql(client, { schema });
+  return dbInstance;
+}
+
+function getOrCreateDb(): SchemaDatabase {
+  if (globalForDb.db) {
+    return globalForDb.db;
+  }
+
+  const dbUrl = process.env.DATABASE_URL || 'file:./data/recoverai.db';
+  const driver = resolveDriver(dbUrl);
+
+  const dbInstance = driver === 'libsql' ? createRemoteDb(dbUrl) : createLocalDb(dbUrl);
+
+  globalForDb.db = dbInstance;
+  return dbInstance;
+}
+
+/**
+ * Confirms a remote database has actually had migrations applied.
+ *
+ * Called by `npm run db:verify` and by the deployment guide, so "I forgot the migrate step"
+ * surfaces as a sentence naming the fix instead of a `no such table: customers` at the first
+ * dashboard request.
+ */
+export async function verifyRemoteSchema(): Promise<{ applied: number; tables: string[] }> {
+  const dbUrl = process.env.DATABASE_URL || '';
+  if (resolveDriver(dbUrl) !== 'libsql') {
+    throw new Error('[db] verifyRemoteSchema is only meaningful for a libsql:// DATABASE_URL.');
+  }
+
+  const client = createClient({ url: dbUrl, authToken: process.env.DATABASE_AUTH_TOKEN });
+  const tables = await client.execute(
+    "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+  );
+  const names = tables.rows.map((r) => String(r.name));
+
+  if (!names.includes(MIGRATIONS_TABLE)) {
+    throw new Error(
+      `[db] The remote database has no ${MIGRATIONS_TABLE} table — migrations have never been ` +
+        'applied. Run `npm run db:migrate` with DATABASE_URL and DATABASE_AUTH_TOKEN set.'
+    );
+  }
+
+  const applied = await client.execute(`SELECT COUNT(*) AS n FROM ${MIGRATIONS_TABLE}`);
+  return { applied: Number(applied.rows[0]?.n ?? 0), tables: names };
+}
+
+export const db = new Proxy({} as SchemaDatabase, {
   get(_target, prop) {
     const instance = getOrCreateDb();
     const val = (instance as unknown as Record<string | symbol, unknown>)[prop];
@@ -201,4 +289,4 @@ export const db = new Proxy({} as BetterSQLite3Database<typeof schema>, {
   },
 });
 
-export type DbClient = BetterSQLite3Database<typeof schema>;
+export type DbClient = SchemaDatabase;

--- a/tests/schema-migration-convergence.test.ts
+++ b/tests/schema-migration-convergence.test.ts
@@ -155,13 +155,55 @@ describe('RA-25 — schema convergence', () => {
     h.close();
   });
 
-  it('rejects a non-file DATABASE_URL rather than treating it as a filename', async () => {
-    process.env.DATABASE_URL = 'libsql://example.turso.io';
+  /**
+   * RA-28 changed this contract: `libsql://` is now served by the Turso driver rather than
+   * rejected. What must still be refused is a scheme neither driver understands — the original
+   * failure was `.replace(/^file:/, '')` leaving a remote URL untouched and better-sqlite3
+   * creating a local file literally named `libsql://…`, so the documented deployment "worked"
+   * and wrote to nowhere.
+   */
+  it('routes each DATABASE_URL scheme to the driver that can serve it', async () => {
     resetDbSingleton();
+    const { resolveDriver } = await import('../src/lib/db');
+
+    expect(resolveDriver('file:./data/recoverai.db')).toBe('better-sqlite3');
+    expect(resolveDriver('libsql://example.turso.io')).toBe('libsql');
+    expect(resolveDriver('https://example.turso.io')).toBe('libsql');
+
+    for (const unsupported of ['postgres://host/db', 'mysql://host/db', 'redis://host', 'db.sqlite']) {
+      expect(() => resolveDriver(unsupported), unsupported).toThrow(/Unsupported DATABASE_URL/);
+    }
+  });
+
+  it('builds a libSQL client for a remote URL rather than a file handle', async () => {
+    process.env.DATABASE_URL = 'libsql://example.turso.io';
+    process.env.DATABASE_AUTH_TOKEN = 'test-token-not-used-offline';
+    resetDbSingleton();
+
+    const { db } = await import('../src/lib/db');
+    const { customers } = await import('../src/lib/db/schema');
+
+    // Building the query must not throw and must not touch the filesystem: @libsql/client
+    // connects lazily, so this exercises driver selection without needing a live database.
+    const query = db.select().from(customers);
+    expect(query.toSQL().sql).toContain('customers');
+    expect(fs.existsSync('libsql://example.turso.io')).toBe(false);
+
+    delete process.env.DATABASE_AUTH_TOKEN;
+  });
+
+  it('refuses a remote database with no auth token instead of connecting anonymously', async () => {
+    process.env.DATABASE_URL = 'libsql://example.turso.io';
+    const previousToken = process.env.DATABASE_AUTH_TOKEN;
+    delete process.env.DATABASE_AUTH_TOKEN;
+    resetDbSingleton();
+
     const { db } = await import('../src/lib/db');
     const { customers } = await import('../src/lib/db/schema');
     // The guard runs inside getOrCreateDb(), which the Proxy invokes synchronously.
-    expect(() => db.select().from(customers)).toThrow(/Unsupported DATABASE_URL/);
+    expect(() => db.select().from(customers)).toThrow(/DATABASE_AUTH_TOKEN is unset/);
+
+    if (previousToken !== undefined) process.env.DATABASE_AUTH_TOKEN = previousToken;
   });
 });
 


### PR DESCRIPTION
## Description

`docs/PRD.md:146` reasoned its way to needing a hosted demo, chose libSQL/Turso specifically because `better-sqlite3` writes to a local filesystem and a naive Vercel deploy *"would appear to work and then silently lose data mid-demo, which is worse than not deploying"* — and then it was never built.

Meanwhile `DEPLOYMENT.md` invited the reader to set `DATABASE_URL=libsql://your-db.turso.io`. The code did this to it:

```ts
const dbPath = dbUrl.replace(/^file:/, '');   // no `file:` prefix → unchanged
const sqlite = new Database(dbPath);          // better-sqlite3 opens a *file*…
```

…so it created a local file literally named `libsql://your-db.turso.io`. The documented deployment didn't error. It wrote to nowhere.

Closes #166

## What this changes

- **Driver selected by URL scheme** — `file:` → `better-sqlite3`, `libsql://` / `https://` → `@libsql/client` through `drizzle-orm/libsql`. Any other scheme throws at startup naming the two it accepts.
- **A remote URL with no `DATABASE_AUTH_TOKEN` fails immediately**, rather than connecting anonymously and failing later on the first query.
- **Local behaviour is untouched** — same driver, same WAL pragma, same legacy-generation adoption, same migrate-on-connect. No `DATABASE_URL` still means `file:./data/recoverai.db`, created and migrated on first connection. That was an acceptance criterion and it's covered by test.

## Remote migrations are deliberately not run on boot

On a serverless host, every cold start would race every other cold start to migrate the single database they all share. Instead `drizzle.config.ts` switches to the Turso dialect when the URL is remote, so the *same* migration files apply once at deploy time:

```bash
DATABASE_URL=libsql://… DATABASE_AUTH_TOKEN=… npm run db:migrate
DATABASE_URL=libsql://… DATABASE_AUTH_TOKEN=… npm run db:verify   # SEED=1 to populate
```

`db:verify` reports how many migrations landed and which tables exist, so a forgotten migrate step surfaces as a sentence naming the fix instead of `no such table: customers` at the first dashboard request.

## Three doc corrections found while rewriting DEPLOYMENT.md

1. **The webhook secret isn't issued by Razorpay.** The table showed `wh_sec_...` as if it had a format. You choose the value and enter it in both the dashboard and `.env`.
2. **The Active Events list was wrong.** It told you to subscribe to five events; `payload.event` is tested exactly once (`route.ts:115`). The other four are verified, recorded, marked `processed`, and have no effect — Razorpay's delivery log shows green while nothing happens. `payment_link.paid` in particular does **not** resolve a recovery journey, so a customer paying through a recovery link isn't reflected on the dashboard by that route.
3. **`RECOVERAI_DEMO_MODE` now carries a warning.** On a public URL it exposes `/api/simulator/seed`, which truncates every table for any anonymous caller.

## Verification

277/277 tests pass (3 new/rewritten), typecheck, lint, `next build` clean.

The scheme test previously asserted `libsql://` must be **rejected** — correct before this change, wrong after — so it's rewritten to the new contract and made stricter: `file:`/`libsql:`/`https:` route to the right driver, and `postgres://`, `mysql://`, `redis://`, `db.sqlite` are all refused. Two more tests cover a remote URL building a real libSQL query without touching the filesystem, and a remote URL with no token failing loudly.

## What's left, and why I can't finish it

The remaining acceptance criteria need account access I don't have:

- [ ] Turso database created, migrated, seeded
- [ ] Vercel project deployed with the §1 variables set
- [ ] Live URL reachable and surviving a demo run

The code half is done and the guide is accurate. When you're ready, the three commands in DEPLOYMENT.md §2 Option B provision the database, and I can drive the verification once the URL exists.

One note for after merge: PR #180 marks task 8.10 ⬜ on the board; with this merged it becomes 🟡 — code done, not yet deployed. I left `TASKS.md` untouched here to avoid conflicting with that PR.