### PR TITLE
fix(auth): treat template placeholders as unconfigured, not as valid secrets

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { timingSafeStringEqual } from '@/lib/auth/crypto';
-import { createSessionToken, SESSION_COOKIE_NAME, SESSION_MAX_AGE_SECONDS } from '@/lib/auth/session';
+import {
+  createSessionToken,
+  isSessionConfigured,
+  SESSION_COOKIE_NAME,
+  SESSION_MAX_AGE_SECONDS,
+} from '@/lib/auth/session';
+import { isTemplatePlaceholder } from '@/lib/config';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,9 +19,24 @@ export async function POST(req: NextRequest) {
     const configuredUsername = process.env.DASHBOARD_USERNAME || '';
     const configuredPassword = process.env.DASHBOARD_PASSWORD || '';
 
-    if (!configuredUsername || !configuredPassword || !process.env.SESSION_SECRET) {
+    // A `.env` copied from `.env.example` leaves all three as their template values. Answering
+    // 401 there is misleading — nothing the operator types can succeed — and issuing a session
+    // signed with the repository's own placeholder secret would be worse than refusing.
+    if (
+      isTemplatePlaceholder(configuredUsername) ||
+      isTemplatePlaceholder(configuredPassword) ||
+      !isSessionConfigured()
+    ) {
       return NextResponse.json(
-        { success: false, error: { code: 'NOT_CONFIGURED', message: 'Dashboard login is not configured' } },
+        {
+          success: false,
+          error: {
+            code: 'NOT_CONFIGURED',
+            message:
+              'Dashboard login is not configured. Set SESSION_SECRET, DASHBOARD_USERNAME and ' +
+              'DASHBOARD_PASSWORD to real values (see .env.example).',
+          },
+        },
         { status: 503 }
       );
     }

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,6 +1,14 @@
 import crypto from 'crypto';
+import { isTemplatePlaceholder } from '../config';
 
 export const SESSION_COOKIE_NAME = 'recoverai_session';
+
+/**
+ * Below this, a signing key is not worth calling one. Deliberately treated as *unconfigured*
+ * rather than accepted, so the proxy's "login isn't set up" path renders pages instead of
+ * looping against a login that cannot be trusted.
+ */
+const MIN_SECRET_LENGTH = 16;
 const SESSION_TTL_MS = 12 * 60 * 60 * 1000; // 12 hours
 export const SESSION_MAX_AGE_SECONDS = SESSION_TTL_MS / 1000;
 
@@ -10,9 +18,29 @@ export const SESSION_MAX_AGE_SECONDS = SESSION_TTL_MS / 1000;
  * needed — the signature and embedded expiry are the whole trust boundary.
  */
 
+/**
+ * The signing key, or null when there isn't a usable one.
+ *
+ * `length > 0` was not enough. `.env.example` ships
+ * `SESSION_SECRET=XXXXXXXXXXXXXXXXXXXXXXXX`, and a `.env` copied verbatim — which is exactly
+ * what the README tells a new contributor to do — satisfied that test. Two consequences, both
+ * real: sessions were signed with a key published in this repository, so anyone could forge a
+ * valid cookie; and the proxy's escape hatch for "login is not configured" never fired, so the
+ * dashboard redirected to a login that could not succeed.
+ */
 function getSessionSecret(): string | null {
   const secret = process.env.SESSION_SECRET;
-  return secret && secret.length > 0 ? secret : null;
+
+  if (isTemplatePlaceholder(secret)) return null;
+  if (secret!.length < MIN_SECRET_LENGTH) {
+    console.warn(
+      `[auth] SESSION_SECRET is ${secret!.length} characters; ${MIN_SECRET_LENGTH} is the minimum. ` +
+        'Treating login as unconfigured.'
+    );
+    return null;
+  }
+
+  return secret!;
 }
 
 export function isSessionConfigured(): boolean {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -13,9 +13,20 @@
 
 export type RecoverAiMode = 'mock' | 'live';
 
-/** Credentials still holding their .env.example placeholder value. */
+/**
+ * A value still holding its `.env.example` template form.
+ *
+ * Exported because the auth layer needs exactly this test and nothing more: a session secret
+ * containing the substring "mock" is a perfectly good secret, while one containing the
+ * `XXXXXXXX` marker is the literal text shipped in the public repository.
+ */
+export function isTemplatePlaceholder(value: string | undefined): boolean {
+  return !value || value.includes('XXXXXXXX');
+}
+
+/** Credentials still holding their .env.example placeholder value, or explicitly mocked. */
 function isPlaceholder(value: string | undefined): boolean {
-  return !value || value.includes('XXXXXXXX') || value.includes('mock');
+  return isTemplatePlaceholder(value) || value!.includes('mock');
 }
 
 export function getMode(): RecoverAiMode {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { checkRateLimit } from '@/lib/utils/rate-limit';
 import { timingSafeStringEqual } from '@/lib/auth/crypto';
 import { isSessionConfigured, verifySessionToken, SESSION_COOKIE_NAME } from '@/lib/auth/session';
+import { isTemplatePlaceholder } from '@/lib/config';
 
 /**
  * One gate in front of every route (RA-05).
@@ -63,7 +64,11 @@ function simulatorSurfaceBlocked(): boolean {
 
 function hasValidCronSecret(req: NextRequest): { configured: boolean; valid: boolean } {
   const configuredSecret = process.env.RECOVERY_SWEEP_SECRET || process.env.CRON_SECRET || '';
-  if (!configuredSecret) {
+
+  // A template placeholder is not a configured secret. Treating it as one made this route
+  // answer 401 ("your secret is wrong") where the honest answer is 503 ("this endpoint has no
+  // secret set up"), and would have accepted a value published in this repository.
+  if (isTemplatePlaceholder(configuredSecret)) {
     return { configured: false, valid: false };
   }
 

--- a/tests/auth-login-route.test.ts
+++ b/tests/auth-login-route.test.ts
@@ -29,7 +29,7 @@ describe('POST /api/auth/login (RA-05)', () => {
   it('rejects wrong credentials with 401 and sets no cookie', async () => {
     vi.stubEnv('DASHBOARD_USERNAME', 'admin');
     vi.stubEnv('DASHBOARD_PASSWORD', 'correct-horse-battery-staple');
-    vi.stubEnv('SESSION_SECRET', 'test-secret');
+    vi.stubEnv('SESSION_SECRET', 'test-secret-0123456789abcdef');
 
     const res = await login(buildLoginRequest({ username: 'admin', password: 'wrong' }));
     expect(res.status).toBe(401);
@@ -39,7 +39,7 @@ describe('POST /api/auth/login (RA-05)', () => {
   it('accepts correct credentials and sets a valid, httpOnly session cookie', async () => {
     vi.stubEnv('DASHBOARD_USERNAME', 'admin');
     vi.stubEnv('DASHBOARD_PASSWORD', 'correct-horse-battery-staple');
-    vi.stubEnv('SESSION_SECRET', 'test-secret');
+    vi.stubEnv('SESSION_SECRET', 'test-secret-0123456789abcdef');
 
     const res = await login(buildLoginRequest({ username: 'admin', password: 'correct-horse-battery-staple' }));
     expect(res.status).toBe(200);
@@ -56,7 +56,7 @@ describe('POST /api/auth/login (RA-05)', () => {
   it('rejects a non-string username/password payload without throwing', async () => {
     vi.stubEnv('DASHBOARD_USERNAME', 'admin');
     vi.stubEnv('DASHBOARD_PASSWORD', 'correct-horse-battery-staple');
-    vi.stubEnv('SESSION_SECRET', 'test-secret');
+    vi.stubEnv('SESSION_SECRET', 'test-secret-0123456789abcdef');
 
     const res = await login(buildLoginRequest({ username: 12345, password: null }));
     expect(res.status).toBe(401);

--- a/tests/auth-placeholder-secrets.test.ts
+++ b/tests/auth-placeholder-secrets.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { proxy } from '../src/proxy';
+import { isSessionConfigured, createSessionToken, SESSION_COOKIE_NAME } from '../src/lib/auth/session';
+import { POST as login } from '../src/app/api/auth/login/route';
+import { resetRateLimitState } from '../src/lib/utils/rate-limit';
+
+/**
+ * A `.env` copied verbatim from `.env.example` — which is exactly what the README tells a new
+ * contributor to do — left `SESSION_SECRET=XXXXXXXXXXXXXXXXXXXXXXXX`. The old check was
+ * `secret.length > 0`, so that counted as configured, with two consequences:
+ *
+ *   1. Sessions were signed with a key published in this repository. Anyone could forge a valid
+ *      cookie for any deployment that had not replaced it.
+ *   2. RA-05's escape hatch for "login is not configured" never fired, so every page redirected
+ *      to a login that could not succeed — the exact trap that code was written to avoid.
+ *
+ * The same blindness made `/api/recovery/*` answer 401 ("your secret is wrong") where the honest
+ * answer was 503 ("no secret is configured here").
+ */
+
+const PLACEHOLDER = 'XXXXXXXXXXXXXXXXXXXXXXXX';
+const REAL_SECRET = 'a-real-secret-0123456789abcdef';
+
+const buildRequest = (path: string, ip: string) =>
+  new NextRequest(new URL(`http://localhost${path}`), {
+    headers: new Headers({ 'x-forwarded-for': ip }),
+  });
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  resetRateLimitState();
+});
+
+describe('placeholder session secret', () => {
+  it('is not a configured secret', () => {
+    vi.stubEnv('SESSION_SECRET', PLACEHOLDER);
+    expect(isSessionConfigured()).toBe(false);
+    expect(createSessionToken('admin')).toBeNull();
+  });
+
+  it('is not rescued by being long', () => {
+    vi.stubEnv('SESSION_SECRET', `${PLACEHOLDER}${PLACEHOLDER}`);
+    expect(isSessionConfigured()).toBe(false);
+  });
+
+  it('rejects a secret too short to be worth signing with', () => {
+    vi.stubEnv('SESSION_SECRET', 'short');
+    expect(isSessionConfigured()).toBe(false);
+  });
+
+  it('accepts a real secret', () => {
+    vi.stubEnv('SESSION_SECRET', REAL_SECRET);
+    expect(isSessionConfigured()).toBe(true);
+    expect(createSessionToken('admin')).toContain('.');
+  });
+
+  it('lets pages render rather than looping to an impossible login', () => {
+    vi.stubEnv('SESSION_SECRET', PLACEHOLDER);
+    const res = proxy(buildRequest('/', '10.9.0.1'));
+    // Not a redirect: the operator sees the dashboard shell and the misconfiguration is
+    // visible, while every API tier below still refuses.
+    expect(res.status).not.toBe(307);
+  });
+
+  it('still refuses the API with a placeholder secret', () => {
+    vi.stubEnv('SESSION_SECRET', PLACEHOLDER);
+    const res = proxy(buildRequest('/api/customers', '10.9.0.2'));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('placeholder login credentials', () => {
+  const post = (body: unknown) =>
+    login(
+      new Request('http://localhost/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }) as never
+    );
+
+  it('answers 503, not 401, when the credentials are still the template', async () => {
+    vi.stubEnv('SESSION_SECRET', REAL_SECRET);
+    vi.stubEnv('DASHBOARD_USERNAME', 'admin');
+    vi.stubEnv('DASHBOARD_PASSWORD', PLACEHOLDER);
+
+    const res = await post({ username: 'admin', password: PLACEHOLDER });
+    // 401 would be a lie: nothing the operator types can succeed.
+    expect(res.status).toBe(503);
+    expect((await res.json()).error.code).toBe('NOT_CONFIGURED');
+  });
+
+  it('will not issue a session signed with the repository placeholder', async () => {
+    vi.stubEnv('SESSION_SECRET', PLACEHOLDER);
+    vi.stubEnv('DASHBOARD_USERNAME', 'admin');
+    vi.stubEnv('DASHBOARD_PASSWORD', 'correct-horse-battery-staple');
+
+    const res = await post({ username: 'admin', password: 'correct-horse-battery-staple' });
+    expect(res.status).toBe(503);
+    expect(res.headers.get('set-cookie')).toBeNull();
+  });
+
+  it('issues a cookie once everything is real', async () => {
+    vi.stubEnv('SESSION_SECRET', REAL_SECRET);
+    vi.stubEnv('DASHBOARD_USERNAME', 'admin');
+    vi.stubEnv('DASHBOARD_PASSWORD', 'correct-horse-battery-staple');
+
+    const res = await post({ username: 'admin', password: 'correct-horse-battery-staple' });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('set-cookie')).toContain(SESSION_COOKIE_NAME);
+  });
+});
+
+describe('placeholder cron secret', () => {
+  it('fails closed with 503 rather than claiming the presented secret was wrong', () => {
+    vi.stubEnv('SESSION_SECRET', REAL_SECRET);
+    vi.stubEnv('RECOVERY_SWEEP_SECRET', PLACEHOLDER);
+
+    const res = proxy(buildRequest('/api/recovery/trigger', '10.9.0.3'));
+    expect(res.status).toBe(503);
+  });
+
+  it('rejects a wrong secret with 401 once a real one is configured', () => {
+    vi.stubEnv('SESSION_SECRET', REAL_SECRET);
+    vi.stubEnv('RECOVERY_SWEEP_SECRET', 'a-real-cron-secret-0123456789');
+
+    const req = new NextRequest(new URL('http://localhost/api/recovery/trigger'), {
+      headers: new Headers({ 'x-forwarded-for': '10.9.0.4', 'x-recovery-secret': 'wrong' }),
+    });
+    expect(proxy(req).status).toBe(401);
+  });
+});

--- a/tests/auth-session.test.ts
+++ b/tests/auth-session.test.ts
@@ -28,22 +28,22 @@ describe('session token creation and verification', () => {
   });
 
   it('creates and verifies a valid token', () => {
-    vi.stubEnv('SESSION_SECRET', 'test-secret-a');
+    vi.stubEnv('SESSION_SECRET', 'test-secret-a-0123456789');
     const token = createSessionToken('admin');
     expect(token).toBeTruthy();
     expect(verifySessionToken(token)).toBe(true);
   });
 
   it('rejects a token signed with a different secret', () => {
-    vi.stubEnv('SESSION_SECRET', 'test-secret-a');
+    vi.stubEnv('SESSION_SECRET', 'test-secret-a-0123456789');
     const token = createSessionToken('admin');
 
-    vi.stubEnv('SESSION_SECRET', 'test-secret-b');
+    vi.stubEnv('SESSION_SECRET', 'test-secret-b-0123456789');
     expect(verifySessionToken(token)).toBe(false);
   });
 
   it('rejects a tampered payload', () => {
-    vi.stubEnv('SESSION_SECRET', 'test-secret-a');
+    vi.stubEnv('SESSION_SECRET', 'test-secret-a-0123456789');
     const token = createSessionToken('admin')!;
     const [payload, signature] = token.split('.');
     const tamperedPayload = Buffer.from(JSON.stringify({ u: 'attacker', exp: Date.now() + 999999 }), 'utf-8').toString(
@@ -54,7 +54,7 @@ describe('session token creation and verification', () => {
   });
 
   it('rejects an expired token', () => {
-    vi.stubEnv('SESSION_SECRET', 'test-secret-a');
+    vi.stubEnv('SESSION_SECRET', 'test-secret-a-0123456789');
     const now = Date.now();
     vi.spyOn(Date, 'now').mockReturnValue(now - 13 * 60 * 60 * 1000); // 13h ago, TTL is 12h
     const token = createSessionToken('admin');
@@ -65,7 +65,7 @@ describe('session token creation and verification', () => {
   });
 
   it('rejects malformed tokens', () => {
-    vi.stubEnv('SESSION_SECRET', 'test-secret-a');
+    vi.stubEnv('SESSION_SECRET', 'test-secret-a-0123456789');
     expect(verifySessionToken('not-a-real-token')).toBe(false);
     expect(verifySessionToken(null)).toBe(false);
     expect(verifySessionToken(undefined)).toBe(false);


### PR DESCRIPTION
## Description

`getSessionSecret()` accepted any non-empty string:

```ts
const secret = process.env.SESSION_SECRET;
return secret && secret.length > 0 ? secret : null;
```

`.env.example` ships `SESSION_SECRET=XXXXXXXXXXXXXXXXXXXXXXXX`. So a `.env` copied verbatim — exactly what the README instructs — passed that check, with two consequences:

1. **Sessions were signed with a key published in this repository.** Anyone could forge a valid cookie for any deployment that hadn't replaced it. That goes from theoretical to urgent the moment RA-28 (#181) gives this project a public URL.
2. **RA-05's escape hatch never fired.** The proxy is written to render pages rather than redirect when login is unconfigured, specifically so an operator isn't trapped against a login that cannot succeed. A placeholder looked configured, so every page redirected to exactly that trap.

The same blindness hit `RECOVERY_SWEEP_SECRET`: a placeholder read as "configured", so `/api/recovery/*` answered `401` ("your secret is wrong") where the documented and honest answer is `503` ("no secret is set up here").

I found this while checking the restored `.env` after the credentials were re-added — the app was locked out and the symptoms didn't match what RA-05's code claimed it would do.

## The fix

- **`isTemplatePlaceholder()`** exported from `config.ts` and shared by the auth layer. It tests only the `XXXXXXXX` marker, deliberately *not* config.ts's extra `"mock"` substring check — a session secret containing "mock" is a fine secret; one containing the marker is literal template text.
- **A secret under 16 characters is treated as unconfigured**, with a warning naming the reason, rather than silently signing with it.
- **`/api/auth/login` answers 503** with a message naming the three variables when any is still a placeholder, instead of 401 on a comparison nobody can win — and never issues a token signed with a placeholder, even if the password happens to be real.

## Verified against a running server

With a `.env` copied straight from `.env.example`:

| Request | Before | After |
| :--- | ---: | ---: |
| `GET /` | 307 → login loop | **200** |
| `GET /api/customers` | 401 | 401 (unchanged — data stays closed) |
| `POST /api/auth/login` | 401 | **503** |
| `POST /api/recovery/trigger` | 401 | **503** |

286/286 tests pass (11 new in `tests/auth-placeholder-secrets.test.ts`), typecheck, lint, `next build` clean.

One note on the diff: existing auth fixtures used 13-character secrets (`test-secret-a`) and now use realistic lengths. That's a fixture change to satisfy the new minimum, not a weakened assertion.