### PR TITLE
feat(webhooks): resolve recovery payments, and make mock mode actually offline

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -91,14 +91,19 @@ To receive live transaction events and trigger autonomous recovery:
    https://recoverai.yourdomain.com/api/webhooks/razorpay
    ```
 4. Enter a strong secret and save it to your `RAZORPAY_WEBHOOK_SECRET` environment variable.
-5. Subscribe to **`payment.failed`** only.
+5. Subscribe to these three:
+   - **`payment.failed`** — detects the failure and starts a recovery journey.
+   - **`payment_link.paid`** — resolves the journey when the customer pays through a recovery
+     link. This is how a real recovery reaches the dashboard.
+   - **`payment.captured`** — resolves the same way when the capture event carries the link.
 
-   That is the sole event the handler acts on — `payload.event` is tested once, at
-   `src/app/api/webhooks/razorpay/route.ts:115`. Any other subscribed event is verified,
-   recorded in `webhook_events`, marked `processed`, and has **no effect on any journey**:
-   Razorpay's delivery log shows green while nothing happens. In particular `payment_link.paid`
-   does *not* resolve a recovery journey today, so a customer paying through a recovery link is
-   not reflected on the dashboard by this route.
+   Attribution is deliberate: a journey is matched only by the payment link id this system
+   stored or the `recov_<journeyId>_att<n>` reference it stamped on the link. A payment carrying
+   neither is recorded and left alone rather than attributed to a guess.
+
+   `subscription.pending`, `subscription.halted` and the other subscription events are **not
+   handled**. Subscribing to them is harmless — they are verified, recorded and ignored — but
+   they will not start or resolve anything, so leave them off.
 6. Trigger a delivery from the dashboard to confirm the wiring end to end.
 
 ---

--- a/docs/issues/RA-33-webhook-resolution-events-ignored.md
+++ b/docs/issues/RA-33-webhook-resolution-events-ignored.md
@@ -1,0 +1,29 @@
+<!-- labels: high,demo-integrity,api,quality -->
+# RA-33 — Four of the five documented webhook events are recorded and then ignored
+
+**Severity:** High · **Area:** `src/app/api/webhooks/razorpay/route.ts` · **Est:** 2-3 h
+
+## Summary
+`payload.event` is tested exactly once in the 262-line webhook handler, for `payment.failed`. Every other event is signature-verified, written to `webhook_events`, marked `processed`, and then dropped.
+
+`docs/DEPLOYMENT.md` meanwhile instructs the operator to subscribe to five events and describes what each one does — including *"`payment_link.paid` (resolves recovery journeys)"*. It does not.
+
+## Impact
+The consequence is the one that matters most for the demo: **a customer who actually pays through a recovery link does not resolve their journey.** The only paths to `resolved` are the simulator's Pay button and the simulation response model, so on a live deployment taking real test-mode payments the dashboard's recovered figure never moves for a genuine recovery.
+
+Razorpay's own delivery log shows `200` for these events, so the integration looks wider and healthier than it is from both sides.
+
+## Proposed fix
+1. Handle `payment_link.paid` and `payment.captured` by resolving the matching journey through `recoveryCoordinator.resolveJourneyWithPayment`, which is already idempotent (RA-09).
+2. Attribute deliberately. Match only on identifiers this system created — the stored `payment_link_id`, or the `recov_<journeyId>_att<n>` reference the coordinator stamps on every link. A payment carrying neither must be recorded and left alone; guessing which open journey it belonged to would fabricate a recovery, which is the failure RA-22 and RA-23 already cost us.
+3. Record the attribution used in the audit trail so a recovered rupee traces back to the outreach that earned it.
+4. Leave the subscription events unhandled, and say so in the deployment guide rather than describing behaviour that does not exist.
+
+## Acceptance criteria
+- [ ] A `payment_link.paid` carrying our reference resolves the journey
+- [ ] A payment carrying no identifier of ours resolves nothing and leaves open journeys untouched
+- [ ] A redelivered event does not double-count the recovery
+- [ ] `docs/DEPLOYMENT.md` lists only events the handler acts on
+
+## Related
+RA-09 (idempotent resolution, which this depends on), RA-28 (a live deployment is what makes this reachable)

--- a/docs/issues/RA-34-mock-mode-makes-real-llm-calls.md
+++ b/docs/issues/RA-34-mock-mode-makes-real-llm-calls.md
@@ -1,0 +1,37 @@
+<!-- labels: medium,demo-integrity,ai-safety,quality -->
+# RA-34 — `RECOVERAI_MODE=mock` still makes real Gemini calls
+
+**Severity:** Medium · **Area:** `src/lib/config.ts` · **Est:** 30 min
+
+## Summary
+`.env.example` documents the mode as *"mock (default) — no outbound calls; payment links and LLM copy are simulated."* That is not what the code does:
+
+```ts
+export function requireCredential(name: string): string | undefined {
+  const value = process.env[name];
+  if (!isLive()) return isPlaceholder(value) ? undefined : value;   // ← hands back a real key
+```
+
+In mock mode a configured `GEMINI_API_KEY` is returned, so `GeminiClient` initialises and every journey makes a live LLM call.
+
+## Evidence
+- A mock-mode batch run through `POST /api/recovery/trigger` took **120 seconds** of real API traffic for 150 journeys.
+- On the deployment, each webhook delivery spent several seconds inside a Gemini call while the declared mode says it makes none.
+
+## Impact
+1. **The declared mode is not the operating mode.** RA-24 established that the whole point of `RECOVERAI_MODE` is that behaviour is declared rather than inferred from whether a credential happens to look real. This is the same defect that fix was written to remove, surviving in the credential accessor.
+2. **It quietly undermines the arms comparison.** Whether the personalisation coefficient fires depends on whether a key is present in the environment, not on the declared configuration — so two runs of the same declared setup can measure different things (RA-22, RA-23).
+3. **Cost and latency arrive unannounced**, on a path documented as offline.
+
+## Proposed fix
+`requireCredential` returns nothing in mock mode, so the deterministic fallbacks run exactly as documented. `readCredential` must stay as it is — webhook signature verification has to work in either mode and already fails closed on a missing secret (RA-01).
+
+Using the models then requires declaring it: `RECOVERAI_MODE=live`.
+
+## Acceptance criteria
+- [ ] A mock-mode run makes no outbound Gemini or Razorpay call, whatever is in the environment
+- [ ] Live mode is verified to work against real credentials
+- [ ] The deployment's intended mode is documented, since running mock means running no AI
+
+## Related
+RA-24 (declared vs inferred mode), RA-22 / RA-23 (the measurement this silently affects)

--- a/src/app/api/webhooks/razorpay/route.ts
+++ b/src/app/api/webhooks/razorpay/route.ts
@@ -14,6 +14,20 @@ import { normalizePhoneE164 } from '@/lib/utils/phone';
 export const dynamic = 'force-dynamic';
 
 
+/**
+ * Makes a request-derived value safe to log (CodeQL js/log-injection).
+ *
+ * `payload.event` comes from the request body. Signature verification runs first, so only a
+ * holder of the webhook secret can reach these lines — but a newline in a logged value forges
+ * log entries wherever those logs are shipped, and "an attacker would need the secret" is a
+ * reason to rank the risk low, not to interpolate raw request data into a log at all.
+ */
+function forLog(value: unknown): string {
+  return String(value ?? '')
+    .replace(/[^\w.:@ -]/g, '')
+    .slice(0, 64);
+}
+
 /** `recov_<journeyId>_att<n>` — the reference the coordinator stamps on every link it creates. */
 function journeyIdFromReference(reference: string | undefined | null): string | null {
   if (!reference) return null;
@@ -59,7 +73,7 @@ async function resolveFromPaymentEvent(
 
   if (!journey) {
     console.warn(
-      `[webhook:razorpay] ${payload.event} carried no link id or recovery reference; ` +
+      `[webhook:razorpay] ${forLog(payload.event)} carried no link id or recovery reference; ` +
         'recording it without attributing a recovery.'
     );
     return { resolvedJourneyId: null, reason: 'no_matching_journey' };

--- a/src/app/api/webhooks/razorpay/route.ts
+++ b/src/app/api/webhooks/razorpay/route.ts
@@ -1,16 +1,93 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { readCredential } from '@/lib/config';
 import { db } from '@/lib/db';
-import { webhookEvents, paymentFailures, customers } from '@/lib/db/schema';
+import { webhookEvents, paymentFailures, customers, recoveryJourneys } from '@/lib/db/schema';
 import { and, eq } from 'drizzle-orm';
 import { verifyWebhookSignature, computePayloadHash } from '@/lib/razorpay/webhooks';
 import { RazorpayWebhookPayload } from '@/lib/razorpay/types';
 import { recoveryCoordinator } from '@/lib/recovery/coordinator';
 import { generateId } from '@/lib/utils/ids';
 import { formatIST, getClock } from '@/lib/utils/time';
+import { writeAuditLog } from '@/lib/utils/audit';
 import { normalizePhoneE164 } from '@/lib/utils/phone';
 
 export const dynamic = 'force-dynamic';
+
+
+/** `recov_<journeyId>_att<n>` — the reference the coordinator stamps on every link it creates. */
+function journeyIdFromReference(reference: string | undefined | null): string | null {
+  if (!reference) return null;
+  const match = reference.match(/^recov_(.+)_att\d+$/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Closes the journey a recovered payment belongs to.
+ *
+ * Attribution is deliberate rather than best-effort: a journey is matched by the payment link id
+ * we stored when we created it, or by the `recov_<journeyId>_att<n>` reference we stamped on it.
+ * Both are our own identifiers, so a match is a fact. A payment that carries neither is recorded
+ * and left alone — guessing which open journey it belonged to would fabricate the one number the
+ * whole project is judged on.
+ */
+async function resolveFromPaymentEvent(
+  payload: RazorpayWebhookPayload
+): Promise<{ resolvedJourneyId: string | null; reason?: string }> {
+  const link = payload.payload.payment_link?.entity;
+  const payment = payload.payload.payment?.entity;
+
+  const linkId = link?.id ?? null;
+  const journeyIdFromRef = journeyIdFromReference(link?.reference_id);
+
+  let journey = null;
+
+  if (journeyIdFromRef) {
+    [journey] = await db
+      .select()
+      .from(recoveryJourneys)
+      .where(eq(recoveryJourneys.id, journeyIdFromRef))
+      .limit(1);
+  }
+
+  if (!journey && linkId) {
+    [journey] = await db
+      .select()
+      .from(recoveryJourneys)
+      .where(eq(recoveryJourneys.paymentLinkId, linkId))
+      .limit(1);
+  }
+
+  if (!journey) {
+    console.warn(
+      `[webhook:razorpay] ${payload.event} carried no link id or recovery reference; ` +
+        'recording it without attributing a recovery.'
+    );
+    return { resolvedJourneyId: null, reason: 'no_matching_journey' };
+  }
+
+  // The amount actually paid, falling back to what the journey put at risk.
+  const amountPaid = payment?.amount ?? journey.amountAtRisk;
+  const paymentId = payment?.id ?? `${payload.event}_${linkId ?? journey.id}`;
+
+  // resolveJourneyWithPayment is idempotent (RA-09), so a Razorpay retry of the same delivery
+  // cannot double-count the recovery even if the idempotency claim above were bypassed.
+  await recoveryCoordinator.resolveJourneyWithPayment(journey.id, paymentId, amountPaid);
+
+  await writeAuditLog({
+    journeyId: journey.id,
+    actor: 'razorpay',
+    eventType: 'payment_recovered_via_webhook',
+    eventData: {
+      event: payload.event,
+      paymentLinkId: linkId,
+      referenceId: link?.reference_id ?? null,
+      amountPaid,
+      attribution: journeyIdFromRef ? 'recovery_reference' : 'payment_link_id',
+    },
+  });
+
+  return { resolvedJourneyId: journey.id };
+}
 
 export async function POST(req: NextRequest) {
   let eventId: string | undefined;
@@ -112,6 +189,29 @@ export async function POST(req: NextRequest) {
     }
 
     // 2. Process Event Types
+    //
+    // A recovered payment closes the journey it belongs to. Before this, `payment_link.paid` and
+    // `payment.captured` were verified, recorded, marked processed and then dropped — so a
+    // customer who actually paid through a recovery link never resolved anything, and the
+    // dashboard's recovered figure could only move via the simulator's Pay button. The
+    // deployment guide meanwhile told operators to subscribe to both.
+    if (payload.event === 'payment_link.paid' || payload.event === 'payment.captured') {
+      const resolution = await resolveFromPaymentEvent(payload);
+
+      await db
+        .update(webhookEvents)
+        .set({
+          processingStatus: 'processed',
+          processedAt: formatIST(getClock().now()),
+        })
+        .where(eq(webhookEvents.id, eventId));
+
+      return NextResponse.json({
+        success: true,
+        data: { eventId, status: 'processed', ...resolution },
+      });
+    }
+
     if (payload.event === 'payment.failed' && payload.payload.payment) {
       const payment = payload.payload.payment.entity;
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -58,7 +58,14 @@ export function readCredential(name: string): string | undefined {
 
 export function requireCredential(name: string): string | undefined {
   const value = process.env[name];
-  if (!isLive()) return isPlaceholder(value) ? undefined : value;
+
+  // Mock mode hands out no credentials, even real ones. `.env.example` promises "mock (default)
+  // — no outbound calls; payment links and LLM copy are simulated", and that was false: a
+  // configured GEMINI_API_KEY was returned here, so the Gemini client initialised and every
+  // journey made a live LLM call. A mock-mode batch run took two minutes of real API traffic,
+  // and the deployed webhook handler spent seconds per delivery on a call the mode says it does
+  // not make. Set RECOVERAI_MODE=live to actually use the models.
+  if (!isLive()) return undefined;
 
   if (isPlaceholder(value)) {
     throw new Error(

--- a/tests/webhook-payment-resolution.test.ts
+++ b/tests/webhook-payment-resolution.test.ts
@@ -247,3 +247,39 @@ describe('payment.captured', () => {
     expect((await res.json()).data.resolvedJourneyId).toBe(journeyId);
   });
 });
+
+describe('log injection (CodeQL js/log-injection)', () => {
+  it('does not let a crafted event name forge log lines', async () => {
+    const journeyId = await seedJourney(null);
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(' '));
+
+    try {
+      await deliver({
+        entity: 'event',
+        account_id: 'acc_test',
+        // A newline here would otherwise append a second, fabricated line to the log stream.
+        event: 'payment_link.paid\n[webhook:razorpay] FORGED payment recovered ₹99999',
+        contains: ['payment_link'],
+        payload: {
+          payment_link: {
+            entity: { id: 'plink_nobody', amount: 100, currency: 'INR', status: 'paid', short_url: 'x' },
+          },
+        },
+        created_at: 1788000000,
+      });
+    } finally {
+      console.warn = original;
+    }
+
+    expect(warnings.join('\n')).not.toContain('FORGED');
+    expect(warnings.join('\n')).not.toMatch(/\n\[webhook:razorpay\] FORGED/);
+
+    const [journey] = await db
+      .select()
+      .from(recoveryJourneys)
+      .where(eq(recoveryJourneys.id, journeyId));
+    expect(journey.status).toBe('recovering');
+  });
+});

--- a/tests/webhook-payment-resolution.test.ts
+++ b/tests/webhook-payment-resolution.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import crypto from 'crypto';
+import { eq } from 'drizzle-orm';
+
+/**
+ * `payment_link.paid` and `payment.captured` were verified, recorded, marked `processed` and then
+ * dropped — `payload.event` was tested exactly once, for `payment.failed`. So a customer who
+ * actually paid through a recovery link resolved nothing: the dashboard's recovered figure could
+ * only move via the simulator's Pay button, while `DEPLOYMENT.md` told operators to subscribe to
+ * both events and claimed one of them "resolves recovery journeys".
+ *
+ * Attribution is the delicate part. A journey is matched only by identifiers this system itself
+ * created — the stored payment link id, or the `recov_<journeyId>_att<n>` reference stamped on
+ * the link. Anything else is recorded and left alone, because guessing which open journey a
+ * payment belonged to would fabricate the one number the project is judged on.
+ */
+
+const SECRET = 'whsec_resolution_test_secret_value';
+
+const { db } = await import('../src/lib/db');
+const { customers, paymentFailures, recoveryJourneys, auditLogs } = await import(
+  '../src/lib/db/schema'
+);
+const { POST: webhook } = await import('../src/app/api/webhooks/razorpay/route');
+const { setClock, FixedClock, SystemClock } = await import('../src/lib/utils/time');
+
+const NOW = '2026-08-21T14:30:00+05:30';
+
+async function seedJourney(paymentLinkId: string | null): Promise<string> {
+  const suffix = crypto.randomUUID();
+  const customerId = `cust_res_${suffix}`;
+  const failureId = `fail_res_${suffix}`;
+  const journeyId = `rj_res_${suffix}`;
+
+  await db.insert(customers).values({
+    id: customerId,
+    name: 'Resolution Fixture',
+    email: `res-${suffix}@example.com`,
+    phone: '+919876500444',
+    preferredLanguage: 'en',
+    segment: 'b2c',
+    totalFailures: 1,
+    totalRecoveredAmount: 0,
+    dndStatus: 'active',
+    createdAt: NOW,
+    updatedAt: NOW,
+  });
+
+  await db.insert(paymentFailures).values({
+    id: failureId,
+    customerId,
+    razorpayPaymentId: `pay_${suffix}`,
+    razorpayOrderId: `order_${suffix}`,
+    amount: 249900,
+    currency: 'INR',
+    paymentMethod: 'card',
+    failureType: 'one_time',
+    errorCode: 'BAD_REQUEST_ERROR',
+    errorSource: 'customer',
+    errorStep: 'authorization',
+    errorReason: 'insufficient_funds',
+    errorDescription: 'Resolution fixture.',
+    arm: 'C',
+    simulationKey: `sim_res_${suffix}`,
+    createdAt: NOW,
+  });
+
+  await db.insert(recoveryJourneys).values({
+    id: journeyId,
+    customerId,
+    failureId,
+    status: 'recovering',
+    strategy: 'payment_link',
+    arm: 'C',
+    amountAtRisk: 249900,
+    amountRecovered: 0,
+    paymentLinkId,
+    maxAttempts: 3,
+    currentAttempt: 1,
+    currentChannel: 'whatsapp',
+    createdAt: NOW,
+    updatedAt: NOW,
+  });
+
+  return journeyId;
+}
+
+/** Signs and delivers a webhook exactly as Razorpay would. */
+async function deliver(payload: Record<string, unknown>) {
+  const rawBody = JSON.stringify(payload);
+  const signature = crypto.createHmac('sha256', SECRET).update(rawBody).digest('hex');
+
+  return webhook(
+    new Request('http://localhost/api/webhooks/razorpay', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-razorpay-signature': signature,
+        'x-razorpay-event-id': `evt_${crypto.randomUUID()}`,
+      },
+      body: rawBody,
+    }) as never
+  );
+}
+
+const linkPaidPayload = (opts: {
+  linkId: string;
+  referenceId?: string;
+  paymentId?: string;
+  amount?: number;
+}) => ({
+  entity: 'event',
+  account_id: 'acc_test',
+  event: 'payment_link.paid',
+  contains: ['payment_link', 'payment'],
+  payload: {
+    payment_link: {
+      entity: {
+        id: opts.linkId,
+        amount: opts.amount ?? 249900,
+        currency: 'INR',
+        status: 'paid',
+        short_url: 'https://rzp.io/i/abc',
+        reference_id: opts.referenceId,
+      },
+    },
+    payment: {
+      entity: { id: opts.paymentId ?? 'pay_recovered_1', amount: opts.amount ?? 249900 },
+    },
+  },
+  created_at: 1788000000,
+});
+
+beforeEach(() => {
+  vi.stubEnv('RAZORPAY_WEBHOOK_SECRET', SECRET);
+  setClock(new FixedClock(NOW));
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+  setClock(new SystemClock());
+});
+
+describe('payment_link.paid resolves the journey it belongs to', () => {
+  it('matches on the recovery reference the coordinator stamped', async () => {
+    const journeyId = await seedJourney(null);
+
+    const res = await deliver(
+      linkPaidPayload({ linkId: 'plink_unknown', referenceId: `recov_${journeyId}_att1` })
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.resolvedJourneyId).toBe(journeyId);
+
+    const [journey] = await db
+      .select()
+      .from(recoveryJourneys)
+      .where(eq(recoveryJourneys.id, journeyId));
+    expect(journey.status).toBe('resolved');
+    expect(journey.amountRecovered).toBe(249900);
+    expect(journey.recoveryPaymentId).toBe('pay_recovered_1');
+  });
+
+  it('falls back to the stored payment link id', async () => {
+    const linkId = `plink_${crypto.randomUUID().slice(0, 8)}`;
+    const journeyId = await seedJourney(linkId);
+
+    const res = await deliver(linkPaidPayload({ linkId, paymentId: 'pay_recovered_2' }));
+    expect((await res.json()).data.resolvedJourneyId).toBe(journeyId);
+
+    const [journey] = await db
+      .select()
+      .from(recoveryJourneys)
+      .where(eq(recoveryJourneys.id, journeyId));
+    expect(journey.status).toBe('resolved');
+  });
+
+  it('records the attribution it used, so a recovery can be traced back', async () => {
+    const journeyId = await seedJourney(null);
+    await deliver(linkPaidPayload({ linkId: 'plink_x', referenceId: `recov_${journeyId}_att2` }));
+
+    const logs = await db.select().from(auditLogs).where(eq(auditLogs.journeyId, journeyId));
+    const entry = logs.find((l) => l.eventType === 'payment_recovered_via_webhook');
+    expect(entry).toBeDefined();
+    expect(JSON.parse(entry!.eventData).attribution).toBe('recovery_reference');
+  });
+
+  it('refuses to guess when the payment carries no identifier of ours', async () => {
+    const journeyId = await seedJourney(null);
+
+    const res = await deliver(linkPaidPayload({ linkId: 'plink_belongs_to_nobody' }));
+    expect(res.status).toBe(200); // recorded, not an error
+    const body = await res.json();
+    expect(body.data.resolvedJourneyId).toBeNull();
+    expect(body.data.reason).toBe('no_matching_journey');
+
+    // The open journey is untouched: attributing a stray payment to it would invent a recovery.
+    const [journey] = await db
+      .select()
+      .from(recoveryJourneys)
+      .where(eq(recoveryJourneys.id, journeyId));
+    expect(journey.status).toBe('recovering');
+    expect(journey.amountRecovered).toBe(0);
+  });
+
+  it('does not double-count a redelivered payment', async () => {
+    const journeyId = await seedJourney(null);
+    const payload = linkPaidPayload({
+      linkId: 'plink_retry',
+      referenceId: `recov_${journeyId}_att1`,
+      paymentId: 'pay_retry_1',
+    });
+
+    await deliver(payload);
+    await deliver(payload); // Razorpay retries on any non-2xx, and events can arrive twice
+
+    const [journey] = await db
+      .select()
+      .from(recoveryJourneys)
+      .where(eq(recoveryJourneys.id, journeyId));
+    expect(journey.amountRecovered).toBe(249900);
+
+    const [customer] = await db
+      .select()
+      .from(customers)
+      .where(eq(customers.id, journey.customerId));
+    expect(customer.totalRecoveredAmount).toBe(249900);
+  });
+});
+
+describe('payment.captured', () => {
+  it('resolves through the same path when it carries the link', async () => {
+    const linkId = `plink_${crypto.randomUUID().slice(0, 8)}`;
+    const journeyId = await seedJourney(linkId);
+
+    const res = await deliver({
+      entity: 'event',
+      account_id: 'acc_test',
+      event: 'payment.captured',
+      contains: ['payment', 'payment_link'],
+      payload: {
+        payment_link: { entity: { id: linkId, amount: 249900, currency: 'INR', status: 'paid', short_url: 'x' } },
+        payment: { entity: { id: 'pay_captured_1', amount: 249900 } },
+      },
+      created_at: 1788000000,
+    });
+
+    expect((await res.json()).data.resolvedJourneyId).toBe(journeyId);
+  });
+});


### PR DESCRIPTION
The last two known gaps from this session's review.
Closes #185
Closes #186

## 1. A real recovery payment resolved nothing

`payload.event` was tested exactly once, for `payment.failed`. `payment_link.paid` and `payment.captured` were verified, recorded, marked `processed` — and dropped. So a customer who actually paid through a recovery link never closed their journey: the dashboard's recovered figure could only move via the simulator's Pay button, while `DEPLOYMENT.md` told operators to subscribe to both and claimed one "resolves recovery journeys".

Both now close the journey they belong to.

**Attribution is deliberate, not best-effort.** A journey is matched only by identifiers this system created:

1. the `recov_<journeyId>_att<n>` reference the coordinator stamps on every link it creates, or
2. the payment link id stored on the journey when the link was created.

A payment carrying neither is recorded and left alone. Guessing which open journey a stray payment belonged to would fabricate the one number this project is judged on — the exact failure mode RA-22 and RA-23 already cost us. There's a test asserting the open journey stays at `amountRecovered = 0` in that case.

Resolution goes through `resolveJourneyWithPayment`, which is idempotent (RA-09), so a Razorpay retry can't double-count — asserted by delivering the same event twice and checking both the journey and the customer's lifetime total.

The attribution used is written to the audit trail, so a recovered rupee traces back to the outreach that earned it.

## 2. `RECOVERAI_MODE=mock` was making real Gemini calls

`.env.example` promises *"mock (default) — no outbound calls; payment links and LLM copy are simulated"*. False: `requireCredential` returned any non-placeholder value in mock mode, so a configured `GEMINI_API_KEY` initialised the client and every journey made a live LLM call.

Measurable, not theoretical — a mock-mode batch run took **two minutes** of real API traffic, and each webhook delivery on the deployment spent seconds inside a call the declared mode doesn't admit to making. It also quietly undermined the arms comparison: whether the personalisation coefficient fired depended on whether a key happened to be present, rather than on the declared configuration.

Mock now hands out no credentials at all. `readCredential` is deliberately untouched — webhook signature verification must work in either mode, and it already fails closed on a missing secret.

## Verification

307/307 tests pass (7 new), typecheck, lint, `next build` clean.

I also verified **live mode genuinely works** against the real credentials, since it 500'd when I probed it earlier and I'd never found out why:

```
razorpay: OK   plink_TX4N40kLitzg3w   https://rzp.io/rzp/skxY7fR
gemini:   OK (LLM copy, not the template fallback)
```

Both integrations succeed. (That check created one ₹1 test-mode payment link in the Razorpay test account.)

## What this means for the deployment

With mock now genuinely offline, the live site currently runs **no AI at all** — the opposite of what you want in an AI buildathon. After merging, set `RECOVERAI_MODE=live` in Vercel:

- Gemini actually generates the recovery copy, which is the thing being judged
- Razorpay creates real test-mode payment links
- and because those links carry the `recov_…` reference, **`payment_link.paid` now closes the loop end to end**: a judge can pay a real test link and watch the journey resolve on the dashboard

Then add `payment_link.paid` and `payment.captured` to the Razorpay webhook's active events.
