### PR TITLE
fix(config): read API credentials on first use, not at module scope

### DIFF
--- a/src/lib/ai/gemini.ts
+++ b/src/lib/ai/gemini.ts
@@ -4,29 +4,45 @@ import { getGeminiModel, requireCredential } from '../config';
 class GeminiClient {
   private client: GoogleGenerativeAI | null = null;
   private model: GenerativeModel | null = null;
-  private apiKey: string;
+  private initialised = false;
 
-  constructor() {
+  /**
+   * Credentials are read on first use, never at construction.
+   *
+   * `export const gemini = new GeminiClient()` runs whenever this module is imported — including
+   * during `next build`, which evaluates every route module to collect page data. Reading a
+   * credential there made the *build* depend on runtime secrets: with RECOVERAI_MODE=live and no
+   * key in the build environment, `requireCredential` threw and the deployment failed with
+   * "Failed to collect configuration for /api/recovery/sweep", nowhere near the actual cause.
+   *
+   * Deferring the read keeps the loud failure where it belongs — the first request that needs a
+   * model — and lets a build succeed without production secrets, which is what a preview
+   * deployment has to be able to do.
+   */
+  private ensureInitialised(): void {
+    if (this.initialised) return;
+    this.initialised = true;
+
     // Throws in live mode when the key is missing or a placeholder, rather than silently
     // leaving this.model null and degrading every message to the template fallback.
-    this.apiKey = requireCredential('GEMINI_API_KEY') || '';
-    if (this.apiKey) {
-      try {
-        this.client = new GoogleGenerativeAI(this.apiKey);
-        this.model = this.client.getGenerativeModel({
-          model: getGeminiModel(),
-        });
-      } catch (error) {
-        console.error('[GeminiClient] Initialization error:', error);
-      }
+    const apiKey = requireCredential('GEMINI_API_KEY') || '';
+    if (!apiKey) return;
+
+    try {
+      this.client = new GoogleGenerativeAI(apiKey);
+      this.model = this.client.getGenerativeModel({ model: getGeminiModel() });
+    } catch (error) {
+      console.error('[GeminiClient] Initialization error:', error);
     }
   }
 
   isAvailable(): boolean {
+    this.ensureInitialised();
     return this.model !== null;
   }
 
   getModel(): GenerativeModel | null {
+    this.ensureInitialised();
     return this.model;
   }
 }

--- a/src/lib/razorpay/client.ts
+++ b/src/lib/razorpay/client.ts
@@ -8,17 +8,30 @@ import { nanoid } from 'nanoid';
 import { isLive, requireCredential } from '../config';
 
 export class RazorpayClient {
-  private keyId: string;
-  private keySecret: string;
+  private keyId = '';
+  private keySecret = '';
   private baseUrl: string;
+  private initialised = false;
 
   constructor() {
-    this.keyId = requireCredential('RAZORPAY_KEY_ID') || '';
-    this.keySecret = requireCredential('RAZORPAY_KEY_SECRET') || '';
     this.baseUrl = 'https://api.razorpay.com/v1';
   }
 
+  /**
+   * Read on first use rather than at construction, for the same reason as GeminiClient: this
+   * module is evaluated during `next build`, and a credential read there makes the build depend
+   * on runtime secrets. A live-mode build with no keys in its environment failed before any
+   * request was served.
+   */
+  private ensureInitialised(): void {
+    if (this.initialised) return;
+    this.initialised = true;
+    this.keyId = requireCredential('RAZORPAY_KEY_ID') || '';
+    this.keySecret = requireCredential('RAZORPAY_KEY_SECRET') || '';
+  }
+
   private getAuthHeader(): string {
+    this.ensureInitialised();
     const auth = Buffer.from(`${this.keyId}:${this.keySecret}`).toString('base64');
     return `Basic ${auth}`;
   }
@@ -29,6 +42,7 @@ export class RazorpayClient {
    * remaining check is only a defensive guard.
    */
   private isMockMode(): boolean {
+    this.ensureInitialised();
     return !isLive() || !this.keyId || !this.keySecret;
   }
 

--- a/tests/mode-configuration.test.ts
+++ b/tests/mode-configuration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { getMode, isLive, readCredential, requireCredential, getGeminiModel, describeIntegrations } from '../src/lib/config';
 
 /**
@@ -66,5 +66,35 @@ describe('preflight', () => {
     expect(line).toContain('mode=mock');
     expect(line).toContain('gemini=unset');
     expect(line).toContain('model=gemini-3.6-flash');
+  });
+});
+
+describe('credentials are never read at module scope', () => {
+  /**
+   * `next build` evaluates every route module to collect page data. Reading a credential in a
+   * client constructor therefore made the *build* depend on runtime secrets: with
+   * RECOVERAI_MODE=live and no key in the build environment, the deployment failed with
+   * "Failed to collect configuration for /api/recovery/sweep" — nowhere near the real cause.
+   *
+   * Importing the modules must stay harmless. The loud failure belongs at first use.
+   */
+  it('importing the clients in live mode with no credentials does not throw', async () => {
+    vi.stubEnv('RECOVERAI_MODE', 'live');
+    vi.stubEnv('GEMINI_API_KEY', 'XXXXXXXXXXXXXXXXXXXX');
+    vi.stubEnv('RAZORPAY_KEY_ID', 'XXXXXXXXXXXXXXXXXXXX');
+    vi.stubEnv('RAZORPAY_KEY_SECRET', 'XXXXXXXXXXXXXXXXXXXX');
+    vi.resetModules();
+
+    await expect(import('../src/lib/ai/gemini')).resolves.toBeDefined();
+    await expect(import('../src/lib/razorpay/client')).resolves.toBeDefined();
+  });
+
+  it('still fails loudly at first use', async () => {
+    vi.stubEnv('RECOVERAI_MODE', 'live');
+    vi.stubEnv('GEMINI_API_KEY', 'XXXXXXXXXXXXXXXXXXXX');
+    vi.resetModules();
+
+    const { gemini } = await import('../src/lib/ai/gemini');
+    expect(() => gemini.isAvailable()).toThrow(/GEMINI_API_KEY is missing or still a placeholder/);
   });
 });


### PR DESCRIPTION
## Description

Setting `RECOVERAI_MODE=live` broke the Vercel build:

```
Error: Failed to collect configuration for /api/recovery/sweep
  [cause]: [config] RECOVERAI_MODE=live but GEMINI_API_KEY is missing or still a placeholder.
```

`next build` evaluates every route module to collect page data, and both API clients read their credentials in a constructor that runs at **module scope**:

```ts
export const gemini = new GeminiClient();   // ← runs on import, i.e. during the build
constructor() { this.apiKey = requireCredential('GEMINI_API_KEY') || ''; }
```

So the *build* depended on runtime secrets. A build environment without them threw during module evaluation, and the error surfaced against an unrelated route — `/api/recovery/sweep` has nothing to do with Gemini — with no hint of the real cause. `RazorpayClient` had the identical pattern.

## The fix

Both clients read credentials on first use. Importing them is harmless; the loud failure stays where it belongs — the first request that actually needs a model or an API call. A preview deployment can now build without production secrets, which it has to be able to do.

Reproduced before fixing rather than guessed:

```
BEFORE:  ✓ Compiled successfully
         Error: Failed to collect configuration for /api/simulator/pay
AFTER:   ✓ Compiled successfully
```

via `GEMINI_API_KEY=XXXXXXXXXXXXXXXXXXXX RECOVERAI_MODE=live npx next build --webpack`.

Two tests cover it: importing both clients in live mode with placeholder credentials must not throw, and `gemini.isAvailable()` must still throw when it is actually used. 310/310 pass.

## Why this is a separate PR

This change was written once before, during #184, and lost. The commit was chained as `git add -A && git reset <paths> && git commit`, and `git reset` with paths exits non-zero when it leaves unstaged changes — so the commit never ran, while the following `git push` reported success and CI went green on a tree that didn't contain the fix. #184 merged without it.

Verified this time by checking `git log` and `git show --stat` after committing, and by confirming the remote head matches.