### PR TITLE
docs(readme): bring it level with what the project now does

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Razorpay AI Buildathon 2026 — Track 3: AI Revenue Recovery**
 
-[Documentation](docs/PROJECT_DOCUMENTATION.md) · [Product Spec](docs/PRD.md) · [Task Board](https://github.com/archittmittal/Recover-AI/issues)
+**[▶ Live demo](https://recover-ai-gules.vercel.app)** · [Documentation](docs/PROJECT_DOCUMENTATION.md) · [Product Spec](docs/PRD.md) · [Task Board](https://github.com/archittmittal/Recover-AI/issues)
 
 [![OpenSSF Scorecard](https://img.shields.io/github/actions/workflow/status/archittmittal/Recover-AI/scorecard.yml?label=OpenSSF%20Scorecard&logo=openssf)](https://github.com/archittmittal/Recover-AI/security/code-scanning?query=tool%3AScorecard)
 [![CodeQL Security Analysis](https://img.shields.io/github/actions/workflow/status/archittmittal/Recover-AI/codeql.yml?label=CodeQL&logo=github)](https://github.com/archittmittal/Recover-AI/actions/workflows/codeql.yml)
@@ -77,13 +77,19 @@ stateDiagram-v2
 
 ## Recovery scenarios covered
 
-| Scenario | Trigger | Recovery action |
-| :--- | :--- | :--- |
-| Failed one-time payment | `payment.failed` | Classify, generate payment link, dispatch via WhatsApp/SMS |
-| Subscription charge failure | `subscription.pending` | Smart retry schedule plus dunning sequence |
-| Subscription halted | `subscription.halted` | Final recovery link plus plan downgrade offer |
-| Checkout abandonment | No payment within threshold | Personalized reminder with cart contents and incentive |
-| Overdue B2B invoice | Invoice `expire_by` passed | Escalating reminder cadence via Invoice Notify API |
+| Scenario | Trigger | Recovery action | Status |
+| :--- | :--- | :--- | :--- |
+| Failed one-time payment | `payment.failed` webhook | Classify, generate a Razorpay payment link, dispatch via WhatsApp → SMS → voice | **Live** |
+| Recovered payment | `payment_link.paid` / `payment.captured` webhook | Journey resolved, attributed to the outreach that earned it | **Live** |
+| Subscription / mandate failure | `payment.failed` on an `emandate` payment | Classified as `smart_retry` or `conversational` by cause, then the same dunning ladder | **Live** |
+| Checkout abandonment | No payment within a 30-minute threshold | Sweep creates the journey and dispatches attempt 1 | **Live** |
+| Overdue B2B invoice | Seeded as an `invoice_overdue` failure | `invoice_reminder` strategy — email first, then WhatsApp, then voice, on a 24h/168h/336h cadence | **Live** |
+| `subscription.pending` / `subscription.halted` | — | Recorded in `webhook_events` and **not acted on**. Subscribing to them changes nothing today | **Not built** |
+
+The subscription-lifecycle events are listed rather than omitted because `docs/DEPLOYMENT.md` used
+to tell operators to subscribe to them and described behaviour that did not exist. Mandate
+failures *are* recovered — they arrive as `payment.failed` on an `emandate` payment, which is the
+path that actually fires.
 
 ---
 
@@ -93,7 +99,7 @@ The agent halts outreach immediately, no exceptions, when any of these fire:
 
 | Rule | Trigger | Result |
 | :--- | :--- | :--- |
-| Payment success | `payment_link.paid` / `subscription.charged` | Journey marked resolved, amount logged |
+| Payment success | `payment_link.paid` / `payment.captured` webhook, or the simulator's Pay button | Journey marked resolved, amount logged, conversion attributed to the outreach that earned it |
 | Customer opt-out | Customer replies "STOP" | Journey marked opted_out, DND set on record |
 | Attempt exhaustion | 3 attempts reached across all channels | Journey marked exhausted, added to exception list |
 | Contact hours | Outside 8 AM to 7 PM IST | Action deferred to next valid window |
@@ -118,6 +124,8 @@ Every batch therefore runs three arms over identical seeded data:
 | C. Full agent | Classification, per-failure strategy, personalised copy, escalation | What does the intelligence add? |
 
 **The honest headline is C minus B.** Arm B is what a cron job and a message template would have achieved on their own; only the delta is attributable to the agent's judgment. The comparison is built before any numbers exist, so the framing cannot be picked after the fact — and if C turns out to be roughly equal to B, that gets reported too.
+
+That promise has already been tested. Under response model v1.0.0 the harness measured **C − B = −7.1 points** across 25 replications: the agent *lost* to the baseline. Rather than bury it, we found the cause — the model's channel term was a single unconditional ranking, so escalating off WhatsApp could only cost, and email was scored badly even for a B2B invoice — declared the fix in an issue **before** touching the model, and re-measured at **+2.8 points**. [`docs/SIMULATION_MODEL.md`](docs/SIMULATION_MODEL.md) carries both numbers, the per-term ablation showing neither change is significant alone, and the plain admission that most of the swing is Arm B falling rather than Arm C rising. Reproduce it yourself with `npm run eval:arms`.
 
 The batch is synthetic, so simulated customer behaviour follows a declared response model — a cause-specific base rate scaled by channel, attempt number, customer segment, and whether the copy came from the LLM or the template fallback — documented coefficient-by-coefficient in [`docs/SIMULATION_MODEL.md`](docs/SIMULATION_MODEL.md) and driven by a fixed seed. **Every coefficient is an estimate, not a measurement**, and the doc labels each one as such; they are declared in advance so the comparison they feed cannot be tuned after the results are in. The agent cannot import that model, and the model cannot import the agent — both directions are asserted by tests, because otherwise it would be marking its own homework. Every figure in the dashboard is labelled as simulation output against that model, never as recovered rupees.
 
@@ -146,10 +154,10 @@ Full reasoning in [`docs/PROJECT_DOCUMENTATION.md`](docs/PROJECT_DOCUMENTATION.m
 
 | Layer | Technology |
 | :--- | :--- |
-| Framework | Next.js 15, App Router, TypeScript |
+| Framework | Next.js 16, App Router, TypeScript |
 | Styling | Tailwind CSS, shadcn/ui |
-| Database | SQLite via `better-sqlite3` |
-| ORM | Drizzle ORM |
+| Database | SQLite via `better-sqlite3` locally; libSQL / Turso when deployed — the driver is chosen from the `DATABASE_URL` scheme |
+| ORM | Drizzle ORM, migrations as the single source of schema truth |
 | AI / LLM | Google Gemini API (`gemini-3.6-flash`, set via `GEMINI_MODEL`) |
 | Charts | Recharts |
 | Payments | Razorpay APIs, test mode — Payment Links, Invoices, Subscriptions, Webhooks |
@@ -179,14 +187,30 @@ the current schema automatically, so evaluating this takes minutes, not a setup 
 no separate `db:migrate` step to remember. Nothing under `data/` is committed: the database is
 generated, and `.gitignore` keeps it that way.
 
+**`RECOVERAI_MODE` decides whether anything leaves the process.** `mock` (the default) makes no
+outbound calls at all: payment links are fabricated and the deterministic template copy ships, so
+a clone with no credentials still runs the whole workflow. `live` uses the real Razorpay test-mode
+API and the real Gemini model. The mode is declared, never inferred from whether a credential
+happens to look real — so *running in mock means running no AI*, which is worth knowing before
+judging the output.
+
 ### Demo flow
 
-1. **Seed the batch** — click "Seed 50+ Failures" on the simulator page.
-2. **Run the agent** — click "Start Recovery" to process every failure.
-3. **Watch the dashboard** — revenue at risk vs. recovered updates live.
-4. **Play as a customer** — reply to agent messages, test the "STOP" opt-out.
-5. **Review the audit trail** — open any customer for the full decision timeline.
-6. **Check the exception list** — see unrecoverable failures with honest reasons.
+1. **Seed the batch** — click "Seed 50+ Failures" on the simulator page. The same 50 failures are
+   materialised into all three experiment arms, so the comparison starts from identical data.
+2. **Run the agent** — click "Run AI Recovery Agent" to process every failure.
+3. **Inject a signed webhook** — the simulator signs a `payment.failed` delivery server-side and
+   feeds it to the real handler, so signature verification is exercised rather than bypassed.
+4. **Cross the contact-hours boundary** — advance the simulated clock to 21:00 IST and run the
+   agent: every outreach defers with its rule logged. Advance to 09:00 and the same queue
+   dispatches. Every jump is written to the audit trail as `clock_advanced`, and time only moves
+   forward, so nothing can be replayed to inflate a result.
+5. **Watch the dashboard** — revenue at risk vs. recovered, and the three-arm comparison with
+   `n` per arm.
+6. **Play as a customer** — reply to agent messages, test the "STOP" opt-out.
+7. **Review the audit trail** — open any customer for the full decision timeline, including the
+   model's own reasoning for each message.
+8. **Check the exception list** — see unrecoverable failures with honest reasons.
 
 ---
 
@@ -227,6 +251,11 @@ Every task in [`docs/TASKS.md`](docs/TASKS.md) has a matching [GitHub Issue](htt
 
 - [`docs/PRD.md`](docs/PRD.md) — product requirements, success criteria, judging-criteria map, milestones
 - [`docs/PROJECT_DOCUMENTATION.md`](docs/PROJECT_DOCUMENTATION.md) — architecture, schema, compliance, LLM prompts, evaluation design
+- [`docs/SIMULATION_MODEL.md`](docs/SIMULATION_MODEL.md) — every coefficient behind the simulated outcomes, each labelled an estimate, plus the measured three-arm result and its history
+- [`docs/AI_DECISIONS.md`](docs/AI_DECISIONS.md) — where an LLM is used, and where it deliberately is not
+- [`docs/ETHICAL_AI_FRAMEWORK.md`](docs/ETHICAL_AI_FRAMEWORK.md) — consent, stopping rules, data minimisation
+- [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) — Turso + Vercel, webhook configuration, environment variables
+- [`docs/DEMO_SCRIPT.md`](docs/DEMO_SCRIPT.md) — scene-by-scene walkthrough of the five-minute demo
 - [`docs/ENGINEERING_LOG.md`](docs/ENGINEERING_LOG.md) — what broke, and how we got out
 - [`docs/TASKS.md`](docs/TASKS.md) — full task breakdown, mirrored as GitHub Issues
 


### PR DESCRIPTION
The README had drifted behind roughly a dozen merged changes. Seven corrections, ordered by how much they matter to someone evaluating this.

## 1. No live URL anywhere

RA-28's entire argument was that a hosted demo *"materially raises the chance the project is actually examined"*. It shipped this morning and the README never mentioned it. Now the first link in the header:

> **[▶ Live demo](https://recover-ai-gules.vercel.app)**

## 2. The measurement section promised a result it never reported

It says: *"if C turns out to be roughly equal to B, that gets reported too."* It didn't report anything.

It now states that under response model v1.0.0 the agent measured **C − B = −7.1 points** — it *lost* — what was wrong with the model, that the fix was declared in an issue **before** the model was touched, and that re-measurement gives **+2.8**, with most of the swing coming from Arm B falling rather than Arm C rising. With `npm run eval:arms` to reproduce.

That's the section a judge is most likely to probe, and it now keeps its own promise.

## 3. The scenarios table claimed four triggers that don't exist

| Claimed | Reality |
| :--- | :--- |
| `subscription.pending` → smart retry + dunning | recorded and ignored |
| `subscription.halted` → recovery link + downgrade offer | recorded and ignored |
| Overdue invoice → "Invoice Notify API" | no such call exists |
| Stopping rule on `subscription.charged` | unhandled |

Each row now carries a **status**, and the unbuilt ones are listed as **Not built** rather than omitted — because `DEPLOYMENT.md` used to tell operators to subscribe to those events and described behaviour that didn't exist. Mandate recovery *is* real; it just arrives as `payment.failed` on an `emandate` payment, which is now what the table says.

## 4–7. The rest

- **Next.js 15 → 16**, and the database row now says better-sqlite3 locally / libSQL-Turso deployed
- **`RECOVERAI_MODE` was undocumented**, which matters most in the direction nobody expects: *running in mock means running no AI at all*
- **The demo flow omitted both things built to be demonstrable** — signed webhook injection, and the contact-hours clock advance that is the best compliance evidence in the project
- **Half the docs were missing from the index** — `SIMULATION_MODEL.md`, `DEPLOYMENT.md`, `AI_DECISIONS.md`, `ETHICAL_AI_FRAMEWORK.md`, `DEMO_SCRIPT.md`

## Verification

Every claim I changed was checked against the code, not assumed — `grep` for the Invoice Notify call, the `payload.event` branches for which webhooks are handled, `package.json` for the Next version. 310/310 tests pass, build clean.