### PR TITLE
fix: close the webhook reconciliation gap and the OpenSSF findings

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,24 +5,28 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Read-only at the top level; the one job that writes asks for it explicitly (OpenSSF Scorecard,
+# Token-Permissions). A repository-wide write token is more than any other step here needs.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update-changelog:
     name: Update Changelog on Main Push
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 2
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Parse Commit & Update CHANGELOG.md
         id: update_changelog
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege by default (OpenSSF Scorecard, Token-Permissions). With no top-level block the
+# job token inherits the repository default, which may be read/write on every scope — far more
+# than any step here needs.
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: Code Quality & Type Safety
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22.x
           cache: 'npm'
@@ -47,16 +53,16 @@ jobs:
       RAZORPAY_KEY_SECRET: mock_secret_for_ci_build
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22.x
           cache: 'npm'
 
       - name: Restore Next.js Cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{ github.workspace }}/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,18 +33,18 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL Analysis Engine
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/db-verify.yml
+++ b/.github/workflows/db-verify.yml
@@ -16,16 +16,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege by default (OpenSSF Scorecard, Token-Permissions). With no top-level block the
+# job token inherits the repository default, which may be read/write on every scope — far more
+# than any step here needs.
+permissions:
+  contents: read
+
 jobs:
   schema-sync:
     name: Check Schema Migration Drift
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22.x
           cache: 'npm'

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -4,16 +4,22 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+# Least privilege by default (OpenSSF Scorecard, Token-Permissions). The semantic-title check
+# reads pull request metadata, so that scope is granted explicitly rather than inherited.
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   pr-metadata:
     name: Verify PR Title & Issue Traceability
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Validate Conventional Commit Title
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -31,7 +37,7 @@ jobs:
           requireScope: false
 
       - name: Validate Issue Linkage
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const prBody = context.payload.pull_request.body || '';
@@ -50,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Assert No Simulation Imports in Agent Engine
         run: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,25 +24,25 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard Analysis
-        uses: ossf/scorecard-action@v2.4.4
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,18 +10,24 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege by default (OpenSSF Scorecard, Token-Permissions). With no top-level block the
+# job token inherits the repository default, which may be read/write on every scope — far more
+# than any step here needs.
+permissions:
+  contents: read
+
 jobs:
   secret-scan:
     name: Secret & Credential Leak Detection
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Run Gitleaks Secret Scanner
-        uses: gitleaks/gitleaks-action@v3
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
@@ -31,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22.x
           cache: 'npm'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/src/app/api/recovery/sweep/route.ts
+++ b/src/app/api/recovery/sweep/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { runCheckoutAbandonmentSweep } from '@/lib/recovery/abandonment-sweep';
+import { findUnprocessedWebhookEvents } from '@/lib/recovery/webhook-reconciliation';
 import { recoveryCoordinator } from '@/lib/recovery/coordinator';
 import { getSimulationSeed, isLive } from '@/lib/config';
 import { runSimulatedOutcomes } from '@/lib/simulation/outcomes';
@@ -30,12 +31,22 @@ export async function POST() {
       );
     }
 
+    // Webhook deliveries whose processing never finished. Since #188 acknowledges before doing
+    // the agent's work, a failure after the response cannot be signalled to Razorpay, so their
+    // retry can never reclaim it — this sweep is the only thing that surfaces those rows.
+    const unprocessedWebhooks = await findUnprocessedWebhookEvents();
+
     return NextResponse.json({
       success: true,
       data: {
         ...result,
         simulatedRecoveries: simulatedRecoveries.length,
         simulationSeed: isLive() ? null : simulationSeed,
+        unprocessedWebhooks: {
+          failed: unprocessedWebhooks.failed.length,
+          stuck: unprocessedWebhooks.stuck.length,
+          events: [...unprocessedWebhooks.failed, ...unprocessedWebhooks.stuck],
+        },
       },
     });
   } catch (error: unknown) {

--- a/src/lib/recovery/webhook-reconciliation.ts
+++ b/src/lib/recovery/webhook-reconciliation.ts
@@ -1,0 +1,83 @@
+import { db } from '../db';
+import { webhookEvents } from '../db/schema';
+import { and, eq, lt } from 'drizzle-orm';
+import { getClock, formatIST } from '../utils/time';
+
+export interface StaleWebhookEvent {
+  id: string;
+  eventType: string;
+  processingStatus: string;
+  errorMessage: string | null;
+  receivedAt: string;
+}
+
+export interface ReconciliationResult {
+  failed: StaleWebhookEvent[];
+  stuck: StaleWebhookEvent[];
+  timestamp: string;
+}
+
+/**
+ * How long an event may sit in `processing` before it counts as stuck rather than in flight.
+ * Deferred processing takes seconds, not minutes; anything past this lost its invocation.
+ */
+const STUCK_AFTER_MINUTES = 15;
+
+/**
+ * Finds webhook deliveries whose processing never completed.
+ *
+ * Acknowledging a delivery before doing the agent's work (#188) bought a fast 2xx at a real cost:
+ * a failure after the response can no longer be signalled to Razorpay, so their retry — the
+ * mechanism RA-10's reclaim path was built around — can never fire for it. The failure is
+ * recorded faithfully in `webhook_events`, but until now nothing ever looked at those rows.
+ *
+ * Two shapes of casualty:
+ *   - `failed` — processing ran and threw. The error message says why.
+ *   - `processing`, older than the threshold — the invocation died mid-flight (a serverless
+ *     timeout, a deploy landing between the claim and the work), so nothing ever wrote an
+ *     outcome. These are the invisible ones: no error, no journey, no trace anywhere else.
+ *
+ * This function only reports. Re-driving a payment event automatically would mean replaying
+ * money movement on rows we know something already went wrong with, and the honest first step is
+ * making them visible rather than guessing at a repair.
+ */
+export async function findUnprocessedWebhookEvents(
+  stuckAfterMinutes: number = STUCK_AFTER_MINUTES
+): Promise<ReconciliationResult> {
+  const now = getClock().now();
+  const cutoff = formatIST(new Date(now.getTime() - stuckAfterMinutes * 60 * 1000));
+
+  const failed = await db
+    .select({
+      id: webhookEvents.id,
+      eventType: webhookEvents.eventType,
+      processingStatus: webhookEvents.processingStatus,
+      errorMessage: webhookEvents.errorMessage,
+      receivedAt: webhookEvents.receivedAt,
+    })
+    .from(webhookEvents)
+    .where(eq(webhookEvents.processingStatus, 'failed'));
+
+  // Timestamps are ISO 8601 with a fixed +05:30 offset, so lexical ordering is chronological.
+  const stuck = await db
+    .select({
+      id: webhookEvents.id,
+      eventType: webhookEvents.eventType,
+      processingStatus: webhookEvents.processingStatus,
+      errorMessage: webhookEvents.errorMessage,
+      receivedAt: webhookEvents.receivedAt,
+    })
+    .from(webhookEvents)
+    .where(
+      and(eq(webhookEvents.processingStatus, 'processing'), lt(webhookEvents.receivedAt, cutoff))
+    );
+
+  if (failed.length > 0 || stuck.length > 0) {
+    console.warn(
+      `[reconciliation] ${failed.length} failed and ${stuck.length} stuck webhook events ` +
+        'need attention — see /api/recovery/sweep output.'
+    );
+  }
+
+  return { failed, stuck, timestamp: formatIST(now) };
+}

--- a/tests/webhook-reconciliation.test.ts
+++ b/tests/webhook-reconciliation.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import crypto from 'crypto';
+
+/**
+ * #188 made the webhook handler acknowledge before doing the agent's work, which cost something
+ * real: a failure after the response cannot be signalled to Razorpay, so their retry — the
+ * mechanism RA-10's reclaim path depends on — can never fire for it.
+ *
+ * The failure is recorded faithfully in `webhook_events`, and until now nothing ever read those
+ * rows. This sweep is what closes that loop, so these tests are about visibility rather than
+ * repair: an event that died must be findable, and a healthy one must not raise a false alarm.
+ */
+
+const { db } = await import('../src/lib/db');
+const { webhookEvents } = await import('../src/lib/db/schema');
+const { findUnprocessedWebhookEvents } = await import('../src/lib/recovery/webhook-reconciliation');
+const { setClock, FixedClock, SystemClock, formatIST } = await import('../src/lib/utils/time');
+
+const NOW = '2026-08-21T14:30:00+05:30';
+const minutesAgo = (n: number) =>
+  formatIST(new Date(Date.parse(NOW) - n * 60 * 1000));
+
+async function seedEvent(status: string, receivedAt: string, errorMessage: string | null = null) {
+  const id = `evt_recon_${crypto.randomUUID()}`;
+  await db.insert(webhookEvents).values({
+    id,
+    eventType: 'payment.failed',
+    payloadHash: crypto.randomUUID(),
+    processingStatus: status,
+    errorMessage,
+    receivedAt,
+    processedAt: status === 'processed' ? receivedAt : null,
+  });
+  return id;
+}
+
+beforeEach(async () => {
+  setClock(new FixedClock(NOW));
+  await db.delete(webhookEvents);
+});
+
+afterAll(() => setClock(new SystemClock()));
+
+describe('unprocessed webhook reconciliation', () => {
+  it('finds an event whose deferred processing threw', async () => {
+    const id = await seedEvent('failed', minutesAgo(2), 'RAZORPAY_KEY_ID is missing');
+
+    const { failed, stuck } = await findUnprocessedWebhookEvents();
+
+    expect(failed.map((e) => e.id)).toEqual([id]);
+    expect(failed[0].errorMessage).toContain('RAZORPAY_KEY_ID');
+    expect(stuck).toHaveLength(0);
+  });
+
+  /**
+   * The invisible casualty: the invocation died between claiming the event and writing an
+   * outcome — a serverless timeout, or a deploy landing mid-flight. No error was ever recorded,
+   * so nothing but the elapsed time distinguishes it from work still in progress.
+   */
+  it('finds an event stuck in processing past the threshold', async () => {
+    const id = await seedEvent('processing', minutesAgo(45));
+
+    const { stuck } = await findUnprocessedWebhookEvents();
+
+    expect(stuck.map((e) => e.id)).toEqual([id]);
+  });
+
+  it('leaves an event that is legitimately still in flight alone', async () => {
+    await seedEvent('processing', minutesAgo(1));
+
+    const { failed, stuck } = await findUnprocessedWebhookEvents();
+
+    // Deferred processing takes seconds. A minute old is working, not broken — raising it would
+    // train an operator to ignore the report.
+    expect(failed).toHaveLength(0);
+    expect(stuck).toHaveLength(0);
+  });
+
+  it('ignores events that completed', async () => {
+    await seedEvent('processed', minutesAgo(60));
+
+    const { failed, stuck } = await findUnprocessedWebhookEvents();
+
+    expect(failed).toHaveLength(0);
+    expect(stuck).toHaveLength(0);
+  });
+
+  it('honours a caller-supplied staleness threshold', async () => {
+    await seedEvent('processing', minutesAgo(10));
+
+    expect((await findUnprocessedWebhookEvents(15)).stuck).toHaveLength(0);
+    expect((await findUnprocessedWebhookEvents(5)).stuck).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
The two follow-ups I flagged but hadn't done.

## 1. The gap #188 knowingly opened

Acknowledging the webhook before doing the agent's work fixed the 18-second response Razorpay was timing out on — at a real cost: once the response has gone out, a failure can't be signalled to the sender, so their retry (the mechanism RA-10's reclaim path depends on) can never fire.

The failure was already recorded faithfully in `webhook_events`. **Nothing ever read those rows.**

`/api/recovery/sweep` now reports two kinds of casualty:

| Kind | What happened |
| :--- | :--- |
| `failed` | Deferred processing ran and threw — the error message says why |
| `processing`, older than 15 min | The invocation died between claiming the event and writing an outcome (serverless timeout, deploy landing mid-flight) |

The second is the one worth having: **no error, no journey, no trace anywhere else** — nothing but elapsed time separates it from work still in progress.

It reports rather than re-drives, deliberately. Automatically replaying a payment event means repeating money movement on rows we already know went wrong; making them visible is the honest first step. A one-minute-old `processing` row is not raised — deferred work takes seconds, and an alarm that fires on healthy rows trains an operator to ignore it.

Five tests: a thrown failure is found, a stuck row is found, an in-flight row is left alone, a completed row is ignored, and the threshold is caller-controllable.

## 2. The OpenSSF findings

The README and `DEPLOYMENT.md` both advertise an *"OpenSSF Production Security Checklist"* while the repo's own Scorecard workflow reported **32 open findings against it** — 27 Pinned-Dependencies, 5 Token-Permissions. Same docs-versus-reality shape as everything else this series has been clearing, on the one claim that's checked automatically and published as a badge.

**Pinned dependencies** — every `uses:` now names a 40-character commit SHA, tag retained as a trailing comment so the version stays readable:

```yaml
uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
```

A tag is a moving pointer: whoever controls the action repo can repoint `@v7` at new code, which then runs with whatever token the workflow grants. Every SHA was resolved from the GitHub API for the tag actually in use — including dereferencing annotated tags to their commit — not hand-copied.

**Token permissions** — `ci.yml`, `db-verify.yml`, `security.yml` and `pr-governance.yml` declared none, so their tokens inherited the repository default. They now declare `contents: read` (plus `pull-requests: read` for the semantic-title check). `changelog.yml` held `contents: write` and `pull-requests: write` at the top level where every step inherited them; the write scopes now sit on the one job that needs them.

## Verification

315/315 tests pass (5 new), typecheck, lint, build clean.

Workflows verified structurally: all seven keep their jobs and permissions blocks, no tabs, **zero remaining unpinned references**. The real proof is this PR's own CI — if a SHA were wrong, these checks wouldn't run at all.