### PR TITLE
fix: three findings from a verification pass over the merged state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
 
       - name: TypeScript Compilation Check
         run: npm run typecheck
@@ -70,7 +70,7 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
 
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build Next.js Application
         run: npm run build

--- a/.github/workflows/db-verify.yml
+++ b/.github/workflows/db-verify.yml
@@ -37,7 +37,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
 
       - name: Generate Schema Diff Check
         run: |

--- a/docs/SIMULATION_MODEL.md
+++ b/docs/SIMULATION_MODEL.md
@@ -164,7 +164,11 @@ The seeded batch materialises the **same 50 failures into three cohorts** (RA-22
 | **C** | Classification, per-failure strategy, personalised copy, channel escalation. | What does the intelligence add? |
 
 Cloning the batch rather than partitioning it holds the failure mix, the amounts and the customer
-segments identical across arms by construction. Partitioning 50 failures three ways would have
+segments identical across arms by construction. Only the seeded cohorts enter the comparison: a
+failure arriving from a live webhook is stamped arm `C` so the agent handles it and the dashboard
+counts it, but it has no counterpart in arms A and B, and letting it in would destroy the very
+property this design exists for. Seeded rows carry a `simulation_key`; ingested ones do not, which
+is what the metrics query filters on. Partitioning 50 failures three ways would have
 left ~17 per arm and a mix that matched only approximately.
 
 **Common random numbers.** Every failure carries a `simulation_key` that is the same in all three

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { customers, paymentFailures, recoveryJourneys, recoveryActions, auditLogs } from '@/lib/db/schema';
-import { desc, eq, sql } from 'drizzle-orm';
+import { desc, eq, ne, sql } from 'drizzle-orm';
 import { getMode, getSimulationSeed, isLive } from '@/lib/config';
 
 export const dynamic = 'force-dynamic';
@@ -261,6 +261,13 @@ export async function GET() {
     // arm's own journeys — the same expression the headline uses — so no numeric literal stands
     // in for a measurement. Arm A's rate is 0 because it never contacts anyone, not because a
     // zero was typed here; if a journey in arm A ever recovered, this would report it.
+    //
+    // Restricted to the seeded experiment cohorts. A failure ingested from a live webhook is
+    // stamped arm 'C' so the agent treats it normally and the dashboard counts it — but it has no
+    // counterpart in arms A and B, so letting it into the comparison destroys the one property
+    // the arms are built on: identical data. Observed on the deployment, where seven injected
+    // webhooks had grown arm C to 57 against 50 apiece, each new one dragging C's rate down and
+    // understating the agent. Seeded rows carry a `simulation_key`; ingested rows do not.
     const armAgg = await db
       .select({
         arm: recoveryJourneys.arm,
@@ -270,6 +277,8 @@ export async function GET() {
         recoveredPaise: sql<number>`COALESCE(SUM(${recoveryJourneys.amountRecovered}), 0)`,
       })
       .from(recoveryJourneys)
+      .innerJoin(paymentFailures, eq(recoveryJourneys.failureId, paymentFailures.id))
+      .where(ne(paymentFailures.simulationKey, ''))
       .groupBy(recoveryJourneys.arm);
 
     const armDefinitions: { arm: 'A' | 'B' | 'C'; label: string; description: string }[] = [

--- a/src/app/api/webhooks/razorpay/route.ts
+++ b/src/app/api/webhooks/razorpay/route.ts
@@ -16,17 +16,26 @@ export const dynamic = 'force-dynamic';
 
 
 /**
- * Makes a request-derived value safe to log (CodeQL js/log-injection).
+ * Every event this handler is willing to name in a log line.
  *
- * `payload.event` comes from the request body. Signature verification runs first, so only a
- * holder of the webhook secret can reach these lines — but a newline in a logged value forges
- * log entries wherever those logs are shipped, and "an attacker would need the secret" is a
- * reason to rank the risk low, not to interpolate raw request data into a log at all.
+ * An allowlist rather than a scrubbing regex. The first attempt at this stripped unsafe
+ * characters from `payload.event`, which is sound — but CodeQL kept flagging it (js/log-injection)
+ * because it cannot prove an arbitrary regex sanitises, and a reader cannot either without
+ * working through the character class. Mapping to a fixed set removes the question: nothing that
+ * reaches the log came from the request body at all, it came from this array.
  */
+const LOGGABLE_EVENTS = [
+  'payment.failed',
+  'payment.captured',
+  'payment_link.paid',
+  'subscription.pending',
+  'subscription.halted',
+  'subscription.charged',
+] as const;
+
 function forLog(value: unknown): string {
-  return String(value ?? '')
-    .replace(/[^\w.:@ -]/g, '')
-    .slice(0, 64);
+  const match = LOGGABLE_EVENTS.find((known) => known === value);
+  return match ?? 'unrecognised_event';
 }
 
 /** `recov_<journeyId>_att<n>` — the reference the coordinator stamps on every link it creates. */

--- a/tests/three-arm-baseline.test.ts
+++ b/tests/three-arm-baseline.test.ts
@@ -238,6 +238,77 @@ describe('RA-22 measured baseline comparison', () => {
     );
   });
 
+  /**
+   * A failure ingested from a live webhook is stamped arm 'C' — the agent should treat it
+   * normally and the dashboard should count it — but it has no counterpart in arms A and B. Left
+   * in the comparison it destroys the property the arms exist for: identical data. Seen on the
+   * deployment, where seven injected webhooks had grown arm C to 57 against 50 apiece.
+   */
+  it('excludes webhook-ingested failures from the comparison', async () => {
+    const before = await getMetrics().then((r) => r.json());
+    const armCBefore = before.data.baselineComparison.arms.find((a: { arm: string }) => a.arm === 'C');
+
+    // An ingested failure looks exactly like a seeded one except that it carries no
+    // simulation_key — nothing generated it against the declared response model.
+    const suffix = crypto.randomUUID();
+    await db.insert(customers).values({
+      id: `cust_ingested_${suffix}`,
+      name: 'Ingested Customer',
+      email: `ingested-${suffix}@example.com`,
+      phone: '+919876500555',
+      preferredLanguage: 'en',
+      segment: 'b2c',
+      totalFailures: 1,
+      totalRecoveredAmount: 0,
+      dndStatus: 'active',
+      createdAt: DAYTIME,
+      updatedAt: DAYTIME,
+    });
+    await db.insert(paymentFailures).values({
+      id: `fail_ingested_${suffix}`,
+      customerId: `cust_ingested_${suffix}`,
+      razorpayPaymentId: `pay_${suffix}`,
+      razorpayOrderId: `order_${suffix}`,
+      amount: 999900,
+      currency: 'INR',
+      paymentMethod: 'card',
+      failureType: 'one_time',
+      errorCode: 'BAD_REQUEST_ERROR',
+      errorSource: 'customer',
+      errorStep: 'authorization',
+      errorReason: 'insufficient_funds',
+      errorDescription: 'Arrived by webhook, not by seed.',
+      arm: 'C',
+      simulationKey: '',
+      createdAt: DAYTIME,
+    });
+    await db.insert(recoveryJourneys).values({
+      id: `rj_ingested_${suffix}`,
+      customerId: `cust_ingested_${suffix}`,
+      failureId: `fail_ingested_${suffix}`,
+      status: 'recovering',
+      strategy: 'payment_link',
+      arm: 'C',
+      amountAtRisk: 999900,
+      amountRecovered: 0,
+      maxAttempts: 3,
+      currentAttempt: 1,
+      currentChannel: 'whatsapp',
+      createdAt: DAYTIME,
+      updatedAt: DAYTIME,
+    });
+
+    const after = await getMetrics().then((r) => r.json());
+    const armCAfter = after.data.baselineComparison.arms.find((a: { arm: string }) => a.arm === 'C');
+
+    expect(armCAfter.journeyCount).toBe(armCBefore.journeyCount);
+    expect(armCAfter.atRiskPaise).toBe(armCBefore.atRiskPaise);
+
+    // Still the same size as the arms it is compared against — the whole point.
+    const armB = after.data.baselineComparison.arms.find((a: { arm: string }) => a.arm === 'B');
+    expect(armCAfter.journeyCount).toBe(armB.journeyCount);
+  });
+
   it('reports Arm A as zero because it recovered nothing, not because a zero was typed', async () => {
     const res = await getMetrics();
     const json = await res.json();


### PR DESCRIPTION
A full verification pass — repo *and* deployment — turned up three things the previous work missed. The most important came from inspecting the production database, not the code.

## 1. Webhook-ingested failures were contaminating the three-arm comparison

```
arm  origin     count   at-risk (paise)
  A  seeded        50        62064600
  B  seeded        50        62064600
  C  seeded        50        62064600
  C  ingested       7         1799300     ← no counterpart in A or B
```

A failure arriving from a live webhook is stamped arm `C` — correctly, so the agent handles it and the dashboard counts it. But it has no counterpart in arms A and B, so **every one that lands grows arm C alone**, destroying the single property the whole design rests on: identical data across arms.

It also biases in the direction that flatters nobody. An ingested failure starts unresolved, so each one drags arm C's rate *down* and understates the agent.

Seven of my own probe webhooks had already grown the deployment's arm C to 57 against 50 apiece. **A judge clicking the simulator's webhook button during the demo would have tilted it further, silently**, and the headline C − B number would have drifted with no indication why.

The comparison now considers only the seeded cohorts. Seeded failures carry a `simulation_key` — they were generated against the declared response model — and ingested ones do not, so that is the filter. The dashboard summary is unchanged: live failures still count toward what the product reports about itself.

## 2. CodeQL `js/log-injection` was still open (#82)

The scrubbing regex from the earlier fix is sound, but CodeQL can't prove an arbitrary regex sanitises — so the alert survived, and honestly a reader can't verify it either without working through the character class.

Replaced with an allowlist of the six Razorpay event names this handler will name in a log line. Nothing reaching the log now comes from the request body at all; it comes from a constant array. That removes the question instead of arguing about it.

## 3. Scorecard's remaining Pinned-Dependencies findings

Three `npmCommand not pinned by hash` alerts at the `npm install` steps. `npm ci` installs exactly what `package-lock.json` specifies and fails if the two disagree, where `npm install` may resolve differently and rewrite the lockfile mid-run.

Verified the lockfile actually supports it before changing CI: `npm ci` against a clean directory installs 512 packages and exits 0.

## Verification performed

| Check | Result |
| :--- | :--- |
| Test suite | **316 passed** (1 new) |
| Typecheck | clean |
| Lint | clean |
| Production build | compiles |
| `drizzle-kit check` (schema drift) | "Everything's fine" |
| CI on `main` | all green except the known changelog-workflow failure (#155) |
| Deployed surface | `/` 307 → login · `/api/customers` 401 · `/api/metrics` 401 · `/api/simulator/seed` 401 · `/api/simulator/clock` 200 · unsigned webhook 400 |
| Production data | 7 webhook events, all `processed`; 20 actions, 7 of them LLM-generated |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved baseline comparisons by excluding live webhook failures that are not part of seeded experiments.
  - Improved webhook event logging by accepting only recognized event names, reducing the risk of unsafe log content.

- **Documentation**
  - Clarified how cloned experiment batches, seeded failures, and live-ingested failures are handled in three-arm comparisons.

- **Chores**
  - Standardized dependency installation in automated workflows for more consistent builds and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->