### PR TITLE
feat(config): let the response model decide outcomes in live mode, explicitly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,14 @@ DATABASE_URL=file:./data/recoverai.db
 #                    placeholder, so a bad paste cannot silently downgrade to simulation.
 RECOVERAI_MODE=mock
 
+# Lets the declared response model decide recovery outcomes even in live mode. Mock mode always
+# simulates — nothing else could, since no real payment can arrive. Live mode normally takes
+# outcomes from Razorpay webhooks, so set this ONLY for a demo that wants real Gemini copy and
+# real payment links together with a populated recovery rate. The dashboard keeps labelling the
+# figures simulated either way (GET /api/metrics reports it under `provenance`).
+# A deployment carrying real merchant traffic must leave this unset.
+SIMULATE_OUTCOMES=false
+
 # Seed for the simulation response model (docs/SIMULATION_MODEL.md), which decides whether a
 # simulated customer pays. Distinct from the fixture seed so that editing the synthetic data
 # does not silently move the recovery outcomes. Only consulted in RECOVERAI_MODE=mock; in live

--- a/docs/SIMULATION_MODEL.md
+++ b/docs/SIMULATION_MODEL.md
@@ -272,8 +272,17 @@ The agent cannot read the model it is scored against, so it cannot mark its own 
 directions are asserted in `tests/simulation-response-model.test.ts` and the first is also
 enforced in CI by the architectural boundary job in `.github/workflows/pr-governance.yml`.
 
-**In `RECOVERAI_MODE=live` no draw is ever taken.** Real customers and real Razorpay webhooks
-decide outcomes; inventing recoveries alongside them would corrupt a real merchant's numbers.
+**In `RECOVERAI_MODE=live` no draw is taken unless `SIMULATE_OUTCOMES=true`.** By default real
+customers and real Razorpay webhooks decide outcomes there; inventing recoveries alongside them
+would corrupt a real merchant's numbers.
+
+That flag exists for the one case the two modes could not serve together — a demo that wants real
+LLM copy and real payment links *and* a populated recovery rate, without waiting for 150 people to
+pay. It is a separate switch rather than a widening of "mock" precisely so the choice is visible
+in the environment rather than implied by the mode, and `GET /api/metrics` reports what is
+actually true under `provenance.outcomesAreSimulated`. The dashboard's "Simulated figures" notice
+therefore stays accurate on a live deployment running with the flag on, which is the entire reason
+that labelling machinery exists. A deployment carrying real merchant traffic leaves it unset.
 
 The manual **Pay** button in the simulator still works, so the live demo keeps its moment. It is
 now additive rather than the only source of outcomes.

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { customers, paymentFailures, recoveryJourneys, recoveryActions, auditLogs } from '@/lib/db/schema';
 import { desc, eq, ne, sql } from 'drizzle-orm';
-import { getMode, getSimulationSeed, isLive } from '@/lib/config';
+import { getMode, getSimulationSeed, shouldSimulateOutcomes } from '@/lib/config';
 
 export const dynamic = 'force-dynamic';
 
@@ -349,8 +349,11 @@ export async function GET() {
         // simulated is the same class of error as the reverse (RA-23).
         provenance: {
           mode: getMode(),
-          outcomesAreSimulated: !isLive(),
-          simulationSeed: isLive() ? null : getSimulationSeed(),
+          // Reports what is actually true rather than inferring it from the mode: a live
+          // deployment with SIMULATE_OUTCOMES=true still produces simulated recoveries, and the
+          // dashboard must keep saying so.
+          outcomesAreSimulated: shouldSimulateOutcomes(),
+          simulationSeed: shouldSimulateOutcomes() ? getSimulationSeed() : null,
         },
       },
     });

--- a/src/app/api/recovery/sweep/route.ts
+++ b/src/app/api/recovery/sweep/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { runCheckoutAbandonmentSweep } from '@/lib/recovery/abandonment-sweep';
 import { findUnprocessedWebhookEvents } from '@/lib/recovery/webhook-reconciliation';
 import { recoveryCoordinator } from '@/lib/recovery/coordinator';
-import { getSimulationSeed, isLive } from '@/lib/config';
+import { getSimulationSeed, shouldSimulateOutcomes } from '@/lib/config';
 import { runSimulatedOutcomes } from '@/lib/simulation/outcomes';
 
 export const dynamic = 'force-dynamic';
@@ -20,7 +20,9 @@ export async function POST() {
     // never resolve, and would misattribute the conversion when the batch run finally arrived
     // and a second attempt was already outstanding.
     const simulationSeed = getSimulationSeed();
-    const simulatedRecoveries = isLive() ? [] : await runSimulatedOutcomes(simulationSeed);
+    const simulatedRecoveries = shouldSimulateOutcomes()
+      ? await runSimulatedOutcomes(simulationSeed)
+      : [];
 
     for (const recovery of simulatedRecoveries) {
       await recoveryCoordinator.resolveJourneyWithPayment(
@@ -41,7 +43,7 @@ export async function POST() {
       data: {
         ...result,
         simulatedRecoveries: simulatedRecoveries.length,
-        simulationSeed: isLive() ? null : simulationSeed,
+        simulationSeed: shouldSimulateOutcomes() ? simulationSeed : null,
         unprocessedWebhooks: {
           failed: unprocessedWebhooks.failed.length,
           stuck: unprocessedWebhooks.stuck.length,

--- a/src/app/api/recovery/trigger/route.ts
+++ b/src/app/api/recovery/trigger/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { paymentFailures, recoveryJourneys } from '@/lib/db/schema';
 import { recoveryCoordinator } from '@/lib/recovery/coordinator';
-import { getSimulationSeed, isLive } from '@/lib/config';
+import { getSimulationSeed, shouldSimulateOutcomes } from '@/lib/config';
 import { runSimulatedOutcomes } from '@/lib/simulation/outcomes';
 
 export const dynamic = 'force-dynamic';
@@ -38,7 +38,9 @@ export async function POST() {
     // In live mode nothing is drawn: real customers and real Razorpay webhooks decide, and
     // inventing recoveries alongside them would corrupt a real merchant's numbers.
     const simulationSeed = getSimulationSeed();
-    const simulatedRecoveries = isLive() ? [] : await runSimulatedOutcomes(simulationSeed);
+    const simulatedRecoveries = shouldSimulateOutcomes()
+      ? await runSimulatedOutcomes(simulationSeed)
+      : [];
 
     for (const recovery of simulatedRecoveries) {
       await recoveryCoordinator.resolveJourneyWithPayment(
@@ -57,12 +59,12 @@ export async function POST() {
         processedCount: processedJourneyIds.length,
         journeyIds: processedJourneyIds,
         simulatedRecoveries: simulatedRecoveries.length,
-        simulationSeed: isLive() ? null : simulationSeed,
+        simulationSeed: shouldSimulateOutcomes() ? simulationSeed : null,
         message:
           `Successfully processed recovery for ${processedJourneyIds.length} failures` +
-          (isLive()
-            ? '.'
-            : `; the response model recovered ${simulatedRecoveries.length} of them (simulated).`),
+          (shouldSimulateOutcomes()
+            ? `; the response model recovered ${simulatedRecoveries.length} of them (simulated).`
+            : '.'),
       },
     });
   } catch (error: unknown) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -108,6 +108,26 @@ export function getSimulationSeed(): number {
   return parsed;
 }
 
+/**
+ * Whether the declared response model decides recovery outcomes.
+ *
+ * In mock mode it always does — nothing else could, since no real payment can arrive. In live
+ * mode outcomes normally come from Razorpay webhooks, and inventing recoveries alongside real
+ * ones would corrupt a real merchant's numbers.
+ *
+ * `SIMULATE_OUTCOMES=true` overrides that for the case the two modes could not previously serve
+ * together: a demo that wants real Gemini copy and real payment links *and* a populated recovery
+ * rate, without waiting for 150 people to pay. It is deliberately a separate switch rather than a
+ * widening of "mock", so the choice is visible in the environment, and `GET /api/metrics` reports
+ * it in `provenance` so the dashboard keeps saying the figures are simulated.
+ *
+ * A deployment carrying real merchant traffic must leave it unset.
+ */
+export function shouldSimulateOutcomes(): boolean {
+  if (!isLive()) return true;
+  return (process.env.SIMULATE_OUTCOMES || '').trim().toLowerCase() === 'true';
+}
+
 /** One line at startup naming what is actually wired, so a silent downgrade is visible. */
 export function describeIntegrations(): string {
   const mode = getMode();

--- a/tests/mode-configuration.test.ts
+++ b/tests/mode-configuration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { getMode, isLive, readCredential, requireCredential, getGeminiModel, describeIntegrations } from '../src/lib/config';
+import { getMode, isLive, readCredential, requireCredential, getGeminiModel, describeIntegrations, shouldSimulateOutcomes } from '../src/lib/config';
 
 /**
  * RA-24 — mock vs live is declared, not inferred from the shape of a credential, and live
@@ -96,5 +96,40 @@ describe('credentials are never read at module scope', () => {
 
     const { gemini } = await import('../src/lib/ai/gemini');
     expect(() => gemini.isAvailable()).toThrow(/GEMINI_API_KEY is missing or still a placeholder/);
+  });
+});
+
+describe('SIMULATE_OUTCOMES', () => {
+  /**
+   * Mock and live were mutually exclusive in a way that served no demo well: mock gave a
+   * populated recovery rate with no AI anywhere, live gave real Gemini copy and real payment
+   * links with nothing ever resolving. This flag is the seam between them, and it must stay
+   * explicit — a live deployment carrying real merchant traffic cannot have simulated recoveries
+   * appear in its numbers by accident.
+   */
+  it('always simulates in mock mode, where nothing else could decide an outcome', () => {
+    vi.stubEnv('RECOVERAI_MODE', 'mock');
+    vi.stubEnv('SIMULATE_OUTCOMES', '');
+    expect(shouldSimulateOutcomes()).toBe(true);
+  });
+
+  it('does not simulate in live mode by default', () => {
+    vi.stubEnv('RECOVERAI_MODE', 'live');
+    vi.stubEnv('SIMULATE_OUTCOMES', '');
+    expect(shouldSimulateOutcomes()).toBe(false);
+  });
+
+  it('simulates in live mode only when explicitly asked', () => {
+    vi.stubEnv('RECOVERAI_MODE', 'live');
+    vi.stubEnv('SIMULATE_OUTCOMES', 'true');
+    expect(shouldSimulateOutcomes()).toBe(true);
+  });
+
+  it('treats anything other than "true" as off', () => {
+    vi.stubEnv('RECOVERAI_MODE', 'live');
+    for (const value of ['false', '1', 'yes', 'TRUE ', 'maybe']) {
+      vi.stubEnv('SIMULATE_OUTCOMES', value);
+      expect(shouldSimulateOutcomes(), value).toBe(value.trim().toLowerCase() === 'true');
+    }
   });
 });


### PR DESCRIPTION
## Description

Mock and live were mutually exclusive in a way that served no demo well:

| | Mock | Live |
| :--- | :--- | :--- |
| Gemini copy | ✗ template only | ✓ real |
| Payment links | ✗ fabricated | ✓ real test-mode |
| Recovery rate | ✓ populated | ✗ nothing resolves |
| Three-arm comparison | ✓ meaningful | ✗ all arms ~0 |

A recording needs both halves. `SIMULATE_OUTCOMES=true` is the seam.

- **Mock always simulates** — nothing else could decide an outcome there.
- **Live simulates only when explicitly told to.**

## Why a separate flag rather than widening "mock"

So the choice is visible in the environment instead of implied by the mode. `GET /api/metrics` now reports what is *actually* true under `provenance.outcomesAreSimulated`, rather than inferring it from `isLive()` — so the dashboard's "Simulated figures" notice keeps telling the truth on a live deployment running with the flag on.

That is the entire reason the RA-23 labelling machinery exists, and this is the first configuration where it earns its keep: real LLM copy, real payment links, and simulated recoveries, all at once, with the page saying plainly which is which.

A deployment carrying real merchant traffic leaves it unset. `.env.example` and `docs/SIMULATION_MODEL.md` both say so.

## Verification

320/320 tests pass (4 new covering the flag's semantics, including that anything other than the literal `true` is off), typecheck, lint, build clean.