### PR TITLE
fix(simulator): stop the Pay button resolving the control arm, and split payment-link mocking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,13 @@ DATABASE_URL=file:./data/recoverai.db
 #                    placeholder, so a bad paste cannot silently downgrade to simulation.
 RECOVERAI_MODE=mock
 
+# Fabricate Razorpay payment links while everything else stays live. Razorpay's TEST MODE CAPS
+# PAYMENT LINKS AT 30 PER ACCOUNT, IN TOTAL — a seeded batch dispatches far more than that, and
+# once the cap is hit every attempt aborts rather than send a dead link. Without this flag the only
+# way to stop calling Razorpay was RECOVERAI_MODE=mock, which also withholds the Gemini key, so an
+# exhausted link quota cost you the LLM as well. Leave unset on a real deployment.
+MOCK_PAYMENT_LINKS=false
+
 # Lets the declared response model decide recovery outcomes even in live mode. Mock mode always
 # simulates — nothing else could, since no real payment can arrive. Live mode normally takes
 # outcomes from Razorpay webhooks, so set this ONLY for a demo that wants real Gemini copy and

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "db:migrate": "drizzle-kit migrate",
     "db:check": "drizzle-kit check",
     "eval:arms": "vitest run --config vitest.eval.mts scripts/evaluate-arms.eval.ts",
-    "db:verify": "vitest run --config vitest.eval.mts scripts/deploy-check.eval.ts"
+    "db:verify": "vitest run --config vitest.eval.mts scripts/deploy-check.eval.ts",
+    "demo:populate": "vitest run --config vitest.eval.mts scripts/populate-demo.eval.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",

--- a/scripts/populate-demo.eval.ts
+++ b/scripts/populate-demo.eval.ts
@@ -1,0 +1,150 @@
+/**
+ * Populates a database with a full, real agent run — for recording the demo.
+ *
+ * Usage:
+ *   DATABASE_URL=libsql://… DATABASE_AUTH_TOKEN=… RECOVERAI_MODE=live SIMULATE_OUTCOMES=true \
+ *     npm run demo:populate
+ *
+ * Two reasons this does not go through `POST /api/recovery/trigger`:
+ *
+ *   1. A live-mode pass makes a real Razorpay payment link and a real Gemini call per journey.
+ *      That is minutes of work, far past any serverless request budget.
+ *   2. The route dispatches every due journey as fast as the loop runs, which Razorpay's test
+ *      environment answers with `429 Too many requests` — observed on the first attempt at this,
+ *      where 23 of ~100 dispatches were rejected and the agent (correctly, per RA-14) aborted
+ *      those attempts rather than send a dead link. Journeys are therefore paced here.
+ *
+ * Time is advanced a day at a time so the retry ladder actually plays out: `invoice_reminder`
+ * schedules attempts at +24h, +168h and +336h, so a run that never moves the clock measures the
+ * window rather than the agent.
+ */
+
+import { it } from 'vitest';
+
+const DAYS = Number(process.env.DEMO_DAYS || 1);
+const PACE_MS = Number(process.env.DEMO_PACE_MS || 900);
+const START = '2026-08-21T14:30:00+05:30';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+it('populates the demo batch', async () => {
+  const url = process.env.DATABASE_URL || '';
+  if (!url.startsWith('libsql://') && !url.startsWith('https://')) {
+    throw new Error(`Point DATABASE_URL at the deployed database first. Got "${url || '(unset)'}".`);
+  }
+
+  const { seedDatabase } = await import('../src/lib/db/seed');
+  const { db } = await import('../src/lib/db');
+  const { recoveryJourneys, recoveryActions, customers, paymentFailures } = await import(
+    '../src/lib/db/schema'
+  );
+  const { setClock, FixedClock, SystemClock } = await import('../src/lib/utils/time');
+  const { recoveryCoordinator } = await import('../src/lib/recovery/coordinator');
+  const { runSimulatedOutcomes } = await import('../src/lib/simulation/outcomes');
+  const { getSimulationSeed, shouldSimulateOutcomes } = await import('../src/lib/config');
+  const { sql, inArray, eq } = await import('drizzle-orm');
+
+  const base = Date.parse(START);
+
+  if (process.env.DEMO_RESEED !== 'false') {
+    console.log('\nreseeding — this clears whatever is there now');
+    setClock(new FixedClock(new Date(base)));
+    const seeded = await seedDatabase();
+    console.log(`seeded ${seeded} failures across three arms\n`);
+  }
+
+  for (let day = 0; day <= DAYS; day++) {
+    setClock(new FixedClock(new Date(base + day * 24 * 3600 * 1000)));
+
+    // Arms A and B and C all have failures; arm A's journeys are created and never dispatched,
+    // which the coordinator enforces itself.
+    const failures = await db.select({ id: paymentFailures.id }).from(paymentFailures);
+    const existing = await db
+      .select({ id: recoveryJourneys.id, failureId: recoveryJourneys.failureId, status: recoveryJourneys.status })
+      .from(recoveryJourneys);
+    const byFailure = new Map(existing.map((j) => [j.failureId, j]));
+
+    let dispatched = 0;
+    let aborted = 0;
+
+    for (const failure of failures) {
+      const journey = byFailure.get(failure.id);
+      const before = await db
+        .select({ n: sql<number>`COUNT(*)` })
+        .from(recoveryActions)
+        .where(journey ? eq(recoveryActions.journeyId, journey.id) : inArray(recoveryActions.id, []));
+
+      try {
+        if (!journey) {
+          await recoveryCoordinator.startRecoveryJourney(failure.id);
+        } else if (journey.status === 'recovering' || journey.status === 'detected') {
+          await recoveryCoordinator.processRecoveryAttempt(journey.id);
+        } else {
+          continue;
+        }
+      } catch (error) {
+        aborted += 1;
+        console.error(`  ${failure.id}: ${error instanceof Error ? error.message.slice(0, 90) : error}`);
+        continue;
+      }
+
+      const [{ n: after }] = journey
+        ? await db
+            .select({ n: sql<number>`COUNT(*)` })
+            .from(recoveryActions)
+            .where(eq(recoveryActions.journeyId, journey.id))
+        : [{ n: 0 }];
+
+      if (after > (before[0]?.n ?? 0)) dispatched += 1;
+
+      // Pace the outbound calls. Razorpay's test environment rejects a burst.
+      await sleep(PACE_MS);
+    }
+
+    const recoveries = shouldSimulateOutcomes()
+      ? await runSimulatedOutcomes(getSimulationSeed())
+      : [];
+    for (const recovery of recoveries) {
+      await recoveryCoordinator.resolveJourneyWithPayment(
+        recovery.journeyId,
+        recovery.paymentId,
+        recovery.amountRecovered,
+        recovery.actionId
+      );
+    }
+
+    console.log(
+      `day ${String(day).padStart(2)}  dispatched ${String(dispatched).padStart(3)}` +
+        `  aborted ${String(aborted).padStart(3)}  recovered ${String(recoveries.length).padStart(3)}`
+    );
+  }
+
+  setClock(new SystemClock());
+
+  const [totals] = await db
+    .select({
+      journeys: sql<number>`COUNT(*)`,
+      resolved: sql<number>`SUM(CASE WHEN ${recoveryJourneys.status} = 'resolved' THEN 1 ELSE 0 END)`,
+      atRisk: sql<number>`SUM(${recoveryJourneys.amountAtRisk})`,
+      recovered: sql<number>`SUM(${recoveryJourneys.amountRecovered})`,
+    })
+    .from(recoveryJourneys);
+
+  const [actions] = await db
+    .select({
+      total: sql<number>`COUNT(*)`,
+      llm: sql<number>`SUM(CASE WHEN ${recoveryActions.isTemplateFallback} = 0 THEN 1 ELSE 0 END)`,
+    })
+    .from(recoveryActions);
+
+  const [{ n: customerCount }] = await db.select({ n: sql<number>`COUNT(*)` }).from(customers);
+
+  console.log('\n--- demo database ---');
+  console.log(`customers          ${customerCount}`);
+  console.log(`journeys           ${totals.journeys}  (${totals.resolved} resolved)`);
+  console.log(`outreach actions   ${actions.total}  (${actions.llm} LLM-generated)`);
+  console.log(
+    `recovered          ₹${Math.round(totals.recovered / 100).toLocaleString('en-IN')} of ` +
+      `₹${Math.round(totals.atRisk / 100).toLocaleString('en-IN')} at risk`
+  );
+}, 2 * 60 * 60 * 1000);

--- a/src/app/api/simulator/pay/route.ts
+++ b/src/app/api/simulator/pay/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { recoveryJourneys } from '@/lib/db/schema';
-import { eq } from 'drizzle-orm';
+import { and, desc, eq, ne } from 'drizzle-orm';
 import { recoveryCoordinator } from '@/lib/recovery/coordinator';
 import { generateId } from '@/lib/utils/ids';
 
@@ -24,10 +24,14 @@ export async function POST(req: NextRequest) {
       const list = await db.select().from(recoveryJourneys).where(eq(recoveryJourneys.id, journeyId)).limit(1);
       if (list.length > 0) journey = list[0];
     } else if (customerId) {
+      // The seeded batch gives every customer one journey per experiment arm, so an unqualified
+      // `limit(1)` picked whichever came first — in practice arm A, the control. Prefer the
+      // agent's own arm; it is the only one a "customer paid" click is about.
       const list = await db
         .select()
         .from(recoveryJourneys)
-        .where(eq(recoveryJourneys.customerId, customerId))
+        .where(and(eq(recoveryJourneys.customerId, customerId), ne(recoveryJourneys.arm, 'A')))
+        .orderBy(desc(recoveryJourneys.arm))
         .limit(1);
       if (list.length > 0) journey = list[0];
     }
@@ -36,6 +40,25 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(
         { success: false, error: { code: 'NOT_FOUND', message: 'Recovery journey not found.' } },
         { status: 404 }
+      );
+    }
+
+    // Arm A answers "what does doing nothing cost?". A recovery in it is not a demo convenience,
+    // it is a contaminated control — and the dashboard would then show the no-agent arm
+    // recovering money, which is incoherent in front of anyone reading carefully. Observed for
+    // real: a Pay click on the deployment resolved rj_KYyKnpXrdUk33Cgx and put ₹6,173 into arm A.
+    if (journey.arm === 'A') {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'CONTROL_ARM',
+            message:
+              'This journey is in arm A, the no-outreach control. Paying it would corrupt the ' +
+              'baseline the comparison depends on.',
+          },
+        },
+        { status: 409 }
       );
     }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -128,6 +128,28 @@ export function shouldSimulateOutcomes(): boolean {
   return (process.env.SIMULATE_OUTCOMES || '').trim().toLowerCase() === 'true';
 }
 
+/**
+ * Whether Razorpay calls are simulated even in live mode.
+ *
+ * Razorpay's test mode caps payment links at **30 per account, in total** — not per minute:
+ *
+ *     429 {"code":"RATE_LIMIT_EXCEEDED",
+ *          "description":"test mode limit of 30 reached for payment_link"}
+ *
+ * A seeded batch dispatches a hundred or more, so a full live run against a test account is not
+ * merely slow, it is impossible. Before this flag the only way to stop calling Razorpay was
+ * `RECOVERAI_MODE=mock`, which also withholds the Gemini key — so an exhausted payment-link quota
+ * silently cost you the LLM as well, which is the one integration that still worked.
+ *
+ * Set `MOCK_PAYMENT_LINKS=true` to fabricate links while everything else stays live. The mode
+ * remains declared rather than inferred; this just makes the declaration finer-grained than one
+ * switch for two very different services.
+ */
+export function shouldMockPaymentLinks(): boolean {
+  if (!isLive()) return true;
+  return (process.env.MOCK_PAYMENT_LINKS || '').trim().toLowerCase() === 'true';
+}
+
 /** One line at startup naming what is actually wired, so a silent downgrade is visible. */
 export function describeIntegrations(): string {
   const mode = getMode();

--- a/src/lib/razorpay/client.ts
+++ b/src/lib/razorpay/client.ts
@@ -5,7 +5,7 @@ import {
   RazorpaySubscriptionEntity,
 } from './types';
 import { nanoid } from 'nanoid';
-import { isLive, requireCredential } from '../config';
+import { requireCredential, shouldMockPaymentLinks } from '../config';
 
 export class RazorpayClient {
   private keyId = '';
@@ -43,7 +43,9 @@ export class RazorpayClient {
    */
   private isMockMode(): boolean {
     this.ensureInitialised();
-    return !isLive() || !this.keyId || !this.keySecret;
+    // MOCK_PAYMENT_LINKS lets a live deployment keep its real Gemini calls while fabricating
+    // links, which is the only workable configuration once a test account's 30-link cap is spent.
+    return shouldMockPaymentLinks() || !this.keyId || !this.keySecret;
   }
 
   /**

--- a/tests/mode-configuration.test.ts
+++ b/tests/mode-configuration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { getMode, isLive, readCredential, requireCredential, getGeminiModel, describeIntegrations, shouldSimulateOutcomes } from '../src/lib/config';
+import { getMode, isLive, readCredential, requireCredential, getGeminiModel, describeIntegrations, shouldSimulateOutcomes, shouldMockPaymentLinks } from '../src/lib/config';
 
 /**
  * RA-24 — mock vs live is declared, not inferred from the shape of a credential, and live
@@ -131,5 +131,39 @@ describe('SIMULATE_OUTCOMES', () => {
       vi.stubEnv('SIMULATE_OUTCOMES', value);
       expect(shouldSimulateOutcomes(), value).toBe(value.trim().toLowerCase() === 'true');
     }
+  });
+});
+
+describe('MOCK_PAYMENT_LINKS', () => {
+  /**
+   * Razorpay's test mode caps payment links at 30 per account in total — discovered the hard way,
+   * mid-batch:
+   *
+   *     429 RATE_LIMIT_EXCEEDED "test mode limit of 30 reached for payment_link"
+   *
+   * Before this flag, the only way to stop calling Razorpay was RECOVERAI_MODE=mock, which also
+   * withholds the Gemini key. An exhausted link quota therefore cost you the LLM too — the one
+   * integration that still worked.
+   */
+  it('mocks links in mock mode, where nothing is called anyway', () => {
+    vi.stubEnv('RECOVERAI_MODE', 'mock');
+    vi.stubEnv('MOCK_PAYMENT_LINKS', '');
+    expect(shouldMockPaymentLinks()).toBe(true);
+  });
+
+  it('uses the real API in live mode by default', () => {
+    vi.stubEnv('RECOVERAI_MODE', 'live');
+    vi.stubEnv('MOCK_PAYMENT_LINKS', '');
+    expect(shouldMockPaymentLinks()).toBe(false);
+  });
+
+  it('fabricates links in live mode when asked, leaving the LLM live', () => {
+    vi.stubEnv('RECOVERAI_MODE', 'live');
+    vi.stubEnv('MOCK_PAYMENT_LINKS', 'true');
+    vi.stubEnv('GEMINI_API_KEY', 'a-real-looking-key');
+
+    expect(shouldMockPaymentLinks()).toBe(true);
+    // The point of the split: Razorpay is off, Gemini is not.
+    expect(requireCredential('GEMINI_API_KEY')).toBe('a-real-looking-key');
   });
 });

--- a/tests/simulator-pay-control-arm.test.ts
+++ b/tests/simulator-pay-control-arm.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import crypto from 'crypto';
+import { eq } from 'drizzle-orm';
+
+/**
+ * Arm A answers "what does doing nothing cost?" — it is the control the whole three-arm
+ * comparison rests on, and nothing in it may ever recover.
+ *
+ * The simulator's Pay button selected a journey with an unqualified `limit(1)` on customer id.
+ * Since the seeded batch gives every customer one journey per arm, that picked arm A in
+ * practice. Observed on the deployment: a single click resolved `rj_KYyKnpXrdUk33Cgx`, put
+ * ₹6,173 into the no-agent arm, and made the dashboard report a control that recovered money —
+ * incoherent in front of anyone reading carefully, and invisible unless someone went looking.
+ */
+
+const { db } = await import('../src/lib/db');
+const { customers, paymentFailures, recoveryJourneys } = await import('../src/lib/db/schema');
+const { POST: pay } = await import('../src/app/api/simulator/pay/route');
+const { setClock, FixedClock, SystemClock } = await import('../src/lib/utils/time');
+
+const NOW = '2026-08-21T14:30:00+05:30';
+let customerId: string;
+const journeyIds: Record<string, string> = {};
+
+beforeEach(async () => {
+  setClock(new FixedClock(NOW));
+
+  const suffix = crypto.randomUUID();
+  customerId = `cust_arms_${suffix}`;
+
+  await db.insert(customers).values({
+    id: customerId,
+    name: 'Three Arm Customer',
+    email: `arms-${suffix}@example.com`,
+    phone: '+919876500777',
+    preferredLanguage: 'en',
+    segment: 'b2c',
+    totalFailures: 3,
+    totalRecoveredAmount: 0,
+    dndStatus: 'active',
+    createdAt: NOW,
+    updatedAt: NOW,
+  });
+
+  // One failure and one journey per arm, exactly as the seeded batch produces.
+  for (const arm of ['A', 'B', 'C'] as const) {
+    const failureId = `fail_${arm}_${suffix}`;
+    await db.insert(paymentFailures).values({
+      id: failureId,
+      customerId,
+      razorpayPaymentId: `pay_${arm}_${suffix}`,
+      razorpayOrderId: `order_${arm}_${suffix}`,
+      amount: 249900,
+      currency: 'INR',
+      paymentMethod: 'card',
+      failureType: 'one_time',
+      errorCode: 'BAD_REQUEST_ERROR',
+      errorSource: 'customer',
+      errorStep: 'authorization',
+      errorReason: 'insufficient_funds',
+      errorDescription: 'Arm fixture.',
+      arm,
+      simulationKey: `sim_${suffix}`,
+      createdAt: NOW,
+    });
+
+    journeyIds[arm] = `rj_${arm}_${suffix}`;
+    await db.insert(recoveryJourneys).values({
+      id: journeyIds[arm],
+      customerId,
+      failureId,
+      status: arm === 'A' ? 'detected' : 'recovering',
+      strategy: arm === 'A' ? 'no_outreach' : 'payment_link',
+      arm,
+      amountAtRisk: 249900,
+      amountRecovered: 0,
+      maxAttempts: arm === 'A' ? 0 : 3,
+      currentAttempt: arm === 'A' ? 0 : 1,
+      currentChannel: arm === 'A' ? null : 'whatsapp',
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+  }
+});
+
+afterAll(() => setClock(new SystemClock()));
+
+const post = (body: unknown) =>
+  pay(
+    new Request('http://localhost/api/simulator/pay', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }) as never
+  );
+
+describe('simulator Pay button and the control arm', () => {
+  it('picks the agent arm when given only a customer', async () => {
+    const res = await post({ customerId });
+    expect(res.status).toBe(200);
+
+    const [armA] = await db
+      .select()
+      .from(recoveryJourneys)
+      .where(eq(recoveryJourneys.id, journeyIds.A));
+    expect(armA.status).toBe('detected');
+    expect(armA.amountRecovered).toBe(0);
+
+    const [armC] = await db
+      .select()
+      .from(recoveryJourneys)
+      .where(eq(recoveryJourneys.id, journeyIds.C));
+    expect(armC.status).toBe('resolved');
+  });
+
+  it('refuses an explicit request to pay a control journey', async () => {
+    const res = await post({ journeyId: journeyIds.A });
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error.code).toBe('CONTROL_ARM');
+
+    const [armA] = await db
+      .select()
+      .from(recoveryJourneys)
+      .where(eq(recoveryJourneys.id, journeyIds.A));
+    expect(armA.amountRecovered).toBe(0);
+  });
+
+  it('still pays a named arm B journey — only the control is off limits', async () => {
+    const res = await post({ journeyId: journeyIds.B });
+    expect(res.status).toBe(200);
+
+    const [armB] = await db
+      .select()
+      .from(recoveryJourneys)
+      .where(eq(recoveryJourneys.id, journeyIds.B));
+    expect(armB.status).toBe('resolved');
+  });
+});


### PR DESCRIPTION
Two fixes found while populating the demo database, both of which would have shown up during filming.

## 1. The Pay button was corrupting the control arm

Arm A answers *"what does doing nothing cost?"* — it is the control the entire three-arm comparison rests on, and nothing in it may ever recover.

The Pay button selected a journey with an unqualified `limit(1)` on customer id. That predates the arms; since the seeded batch now gives every customer one journey per arm, it picked **arm A** in practice. Observed on the live deployment:

```
journey  rj_KYyKnpXrdUk33Cgx   arm A   no_outreach   actions 0
audit    attempt_aborted   {"reason":"arm_a_no_outreach_control"}
audit    payment_recovered {"paymentId":"pay_sim_cust_..."}   ← one Pay click
```

₹6,173 into the no-agent arm. Nothing errored, nothing logged a problem, and the only symptom was arm A reading **1.0%** instead of 0 — a control that recovered money, which is incoherent to anyone reading carefully.

**This would have happened live, the first time anyone clicked Pay during the demo.**

Selecting by customer now prefers the agent's arm, and an explicit request to pay an arm A journey is refused with `409 CONTROL_ARM`. A demo convenience is not worth a contaminated baseline. Three tests cover it, and the contaminated row on the deployment has been repaired.

## 2. Payment-link mocking split from the global mode

Razorpay's test mode caps payment links at **30 per account, in total**:

```
429 {"code":"RATE_LIMIT_EXCEEDED",
     "description":"test mode limit of 30 reached for payment_link"}
```

A seeded batch dispatches a hundred or more, so a full live run against a test account is not slow — it is impossible. Once the cap is reached every attempt aborts rather than send a dead link (RA-14, working as intended), producing 150 journeys and zero outreach.

The only existing way to stop calling Razorpay was `RECOVERAI_MODE=mock`, which also withholds the Gemini key — so an exhausted link quota silently cost the LLM too, the one integration that still worked and the only one that matters for showing an AI agent doing its job.

`MOCK_PAYMENT_LINKS=true` fabricates links while everything else stays live. The mode is still declared rather than inferred; the declaration is simply finer-grained than one switch for two services with very different constraints.

## Result

With both in place the demo database populated cleanly:

```
ARM   n   resolved   rate
  A   50      0       0.0%
  B   50     18      15.7%
  C   50     21      19.6%
C − B = +3.9 points
```

326 tests pass, typecheck, lint, build clean.