### PR TITLE
fix(audit): show the agent's journey, and surface clock advances

### DIFF
--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -1,116 +1,280 @@
-# RecoverAI: 5-Minute Demo Video & Pitch Script
+# RecoverAI — 5-Minute Demo Video & Pitch Script
 
-> **Track**: Razorpay Buildathon 2026 — Track 3 (Autonomous Revenue Recovery Agent)  
-> **Target Length**: 4:30 – 5:00 minutes  
-> **Presenter**: Archit Mittal
+> **Track:** Razorpay AI Buildathon 2026 — Track 3 (Autonomous Revenue Recovery)
+> **Target length:** 4:30 – 5:00
+> **Presenter:** Archit Mittal
+
+Razorpay's submission is three things: a public repo, architecture documentation, and a five-minute
+video. There is no resume screen — shortlisted builders go straight to a panel interview, so this
+video is the filter.
+
+The stated evaluation signals are: working functionality, code quality and execution depth, measured
+results, audit trails and explainability, and graceful failure handling. Every one needs a visible
+moment on screen. The Track 3 bar is narrower still — *measured money recovered with compliant
+escalation and audit documentation*.
 
 ---
 
-## 🎬 Video Production Overview
+## Rule zero: read numbers off the screen
 
-| Time | Scene | On-Screen Action | Key Talking Points |
+Every figure below was measured on 2026-09-05 against the real app, and is recorded here so you know
+what to expect — **not so you can quote it.** Seeds, timing and clock position move these. If the
+screen and this document disagree, the screen wins and this document is stale.
+
+---
+
+## Pre-flight (do this before recording)
+
+Verified working end to end on 2026-09-05. Follow it exactly; the ordering matters.
+
+**1. Decide the mode, and say which one you are in.**
+
+`.env` currently has `RECOVERAI_MODE=mock`. In mock mode **no Gemini call and no Razorpay call is
+made** — copy comes from deterministic templates. That is a legitimate demo, but it means you cannot
+claim the LLM is writing the messages you are showing.
+
+- Demoing in **mock**: say "running in mock mode, so message copy is the deterministic template
+  fallback" once, early. Do not describe personalised AI copy.
+- Demoing in **live**: set `RECOVERAI_MODE=live` and confirm the preflight line names it. Live mode
+  refuses to start on placeholder credentials, which is the point of the flag.
+
+Whichever you pick, the three-arm numbers are unaffected — the personalisation coefficient does not
+fire in mock mode either way (RA-24).
+
+**2. Build the demo state.** Log in, then on `/simulator`, in this order:
+
+| # | Action | What it produces |
+| :--- | :--- | :--- |
+| 1 | **Seed 50+ Failures Batch** | 150 failures — the same 50 materialised into arms A, B and C |
+| 2 | **21:00 (after hours)**, then **Run AI Recovery Agent** | Zero dispatches. This is the deferral shot. |
+| 3 | **09:00 (next morning)**, then **Run AI Recovery Agent** | First WhatsApp wave, first resolutions |
+| 4 | **+24 hours** → **Run**, three times | Escalation to SMS then voice; exhaustion; a populated exception list |
+
+Step 4 is not optional. After step 3 only WhatsApp has fired — SMS and voice both sit at zero
+attempts, and the escalation ladder is the thing you are claiming. Three more days of simulated time
+is what makes attempts 2 and 3 real.
+
+**Measured after the full sequence (2026-09-05):**
+
+- ₹620,646 at risk, ₹140,854 recovered, 22.7%
+- Arm A 0% · Arm B 20% · **Arm C 22.7% · net lift +2.7 pts**
+- WhatsApp 167 attempts / 33 recovered · SMS 32 / 9 · Voice 18 / 3 · Email 10 / 1
+- 24 resolved, 17 exhausted, 1 opted out, 8 still recovering
+- 98 `outside_contact_hours` stopping-rule events, 2 `dnd_active`
+
+**3. Verify the suite.** `npm test` → **335 tests across 48 files, ~3 seconds.** Run it once
+beforehand so it is warm and finishes on camera.
+
+**4. Pre-open every tab** in order: `/`, `/simulator`, `/customers`, a terminal, and
+`docs/ENGINEERING_LOG.md`. Never type a URL on camera.
+
+---
+
+## Shot list
+
+| Time | Scene | Screen | Point being made |
 | :--- | :--- | :--- | :--- |
-| **0:00 – 0:45** | **Hook & The Problem** | Title slide / Hero Dashboard with ₹ at Risk | Razorpay merchants lose 15–20% of GMV to avoidable declines. Static dunning has low conversion; non-compliant outreach risks heavy penalties. |
-| **0:45 – 1:45** | **Executive Dashboard & 3-Arm Lift** | Navigate `/` → Highlight Metrics Cards & 3-Arm Chart | 6 Real-time KPIs. Three-arm comparison over one seeded batch, every rate measured from that arm's own journeys. **Read the lift off the screen — do not quote a number from this script.** |
-| **1:45 – 2:45** | **Multi-Channel Escalation, Contact Hours & Audit** | `/simulator` → advance the clock to 21:00 IST, run the agent, advance to 09:00 → "Customers" → Audit Timeline | WhatsApp (Attempt 1) → SMS (Attempt 2) → AI Voice (Attempt 3). Outreach **defers** after 19:00 IST with a logged reason, then resumes in the morning. Immutable audit logs, including the `clock_advanced` rows. |
-| **2:45 – 3:45** | **Interactive Sandbox & Stopping Rules** | Navigate `/simulator` → inject a signed webhook → Select customer → Trigger "Pay Now" & "STOP" | Dual-panel testbed. Live payment link settlement; instant STOP opt-out compliance (Stopping Rule #2); live IST RBI contact hours clock (8AM–7PM). |
-| **3:45 – 4:30** | **OpenSSF Security & Architecture** | Show test suite (`npm test`) & CI workflows | Timing-safe HMAC verification (`crypto.timingSafeEqual`), DPDPA zero PII in prompts, append-only audit trail, 21/21 automated invariant tests. |
-| **4:30 – 5:00** | **Summary & Business ROI** | Return to Overview Dashboard | RecoverAI turns failed payments into settled revenue without risking customer trust or compliance. |
+| 0:00–0:35 | Cold open | Dashboard, ₹ at risk | The problem, and that this agent acts rather than alerts |
+| 0:35–1:35 | Measurement | Three-arm chart | C − B, and the sign flip. Your strongest card. |
+| 1:35–2:45 | Compliance + audit | `/simulator` clock → audit timeline | Deferral is visible, escalation is real, every event logged |
+| 2:45–3:35 | Stopping rules | Simulator STOP / Pay | Graceful failure, and the no-guess classifier |
+| 3:35–4:25 | Engineering | `npm test`, the `upi://` finding | Depth, and adversarial self-review |
+| 4:25–4:50 | Close | Engineering log | Honest record |
 
 ---
 
-## 🎙️ Spoken Script (Word-for-Word)
+## Spoken script
 
-### [0:00 – 0:45] The Revenue Leakage Crisis
-> *"Hello judges! For Indian internet businesses processing crores on Razorpay, payment failures represent a silent 15 to 20% revenue leakage. When an authorization fails—whether due to 3DS timeouts, daily limits, or expired cards—standard dunning is blunt: generic emails that go to spam, or aggressive phone calls that violate RBI guidelines.*
-> 
-> *Welcome to **RecoverAI**, an autonomous, compliance-first revenue recovery agent built specifically for Razorpay's ecosystem. RecoverAI diagnoses the exact failure root-cause, orchestrates intelligent multi-channel failover, and speaks to customers in natural Hinglish—all while enforcing strict regulatory stopping rules."*
+### [0:00 – 0:35] Cold open
+
+No greeting. No unsourced market-size number.
+
+> "A payment fails at the issuer. A checkout dies at the OTP screen. A subscription mandate breaks on
+> renewal. An invoice goes overdue. Individually, small leaks. Together, that is how Indian merchants
+> lose revenue — silently, and nobody is watching.
+>
+> RecoverAI is an autonomous agent that closes the loop: detect, diagnose, decide, execute, measure.
+> Not an alert — it runs the recovery until the money is back or a hard rule stops it. Let me show
+> you it running."
 
 ---
 
-### [0:45 – 1:45] Command Center & Scientific 3-Arm Evaluation
-> *(Screen shows `http://localhost:3000`)*
-> *"Here in the Executive Command Center, merchants have full visibility into revenue at risk versus recovered. 
-> 
-> Rather than making ungrounded claims, RecoverAI evaluates itself through a **three-arm comparison** over one seeded batch, materialised into three identical cohorts:
-> - **Arm A**: no agent — detected and recorded, never contacted.
-> - **Arm B**: rules-only dunning — fixed cadence, one template, no LLM.
-> - **Arm C**: the full agent.
-> 
-> The metric that matters is the **Net Lift (C minus B)**, and every one of those three rates is computed from that arm's own journeys — there is no constant anywhere in the metrics route."*
+### [0:35 – 1:35] The measurement
 
-> **Presenter note — read the number off the screen, and say where it came from.**
-> Over 25 replications (`npm run eval:arms`, recorded in `docs/SIMULATION_MODEL.md`), C − B is
-> **+2.8 points by amount and +0.7 by journeys** — positive in 24 of 25 runs. Do not stop there,
-> because the interesting part is the history:
+Screen: `/` — metrics cards and the three-arm panel.
+
+> "First, how I know it works — because a recovery rate on its own is unfalsifiable. Recovered versus
+> *what?*
 >
-> - Under response model **v1.0.0** the same harness measured **−7.1 points**. The agent lost.
-> - **v1.1.0** changed two coefficients — email fits a B2B invoice, and a message repeated on the
->   channel that was just ignored decays — and the sign flipped.
-> - The ablation says **neither change alone is significant**, and that most of the swing is Arm B
->   *falling* rather than Arm C rising.
-> - By journey count the edge is under half a journey in fifty. In plain terms: under this model
->   the agent's measurable advantage is mostly that it sends invoices by email.
+> Every batch runs three arms over identical seeded data. Arm A: no agent, detected and recorded,
+> never contacted. Arm B: rules-only dunning — fixed cadence, one template, no LLM. Arm C: the full
+> agent. The honest headline is C minus B, because Arm B is what a cron job and a message template
+> would have achieved on their own.
 >
-> Say that out loud. A judge who hears "we measured −7, we found the reason, we declared the fix
-> in an issue before we made it, we re-measured at +2.8 and here is the ablation showing how much
-> of that is the baseline moving" learns far more about this team than one who hears a headline
-> percentage. And the personalisation coefficient still never fires in mock mode, so none of this
-> is evidence for or against the LLM copy — that needs a live key (RA-24)."*
+> On this batch, that is **[read A, B, C and the lift off the screen]**.
+>
+> But here is the part I would rather you knew. Under the first version of my response model, the
+> same harness measured **minus 7.1 points** — the agent lost. I found the reason, declared the fix
+> in an issue before making it, re-measured, and ran an ablation. The ablation says neither change
+> alone is significant, and that most of the swing is Arm B *falling* rather than Arm C rising. By
+> journey count the edge is under half a journey in fifty.
+>
+> The customers are synthetic, so I do not get to claim rupees. The response model lives in its own
+> file with benchmark-sourced coefficients and a fixed seed, and no agent code is allowed to import
+> it — otherwise the agent is marking its own homework."
+
+**Presenter note.** Two different numbers exist and they are not interchangeable. The dashboard shows
+**one batch**. `npm run eval:arms` shows **+2.8 points by amount, +0.7 by journeys, positive in 24 of
+25 replications**, recorded in `docs/SIMULATION_MODEL.md`. Say which one you are quoting. Conflating
+them is the exact failure this project spent an engineering-log entry on.
 
 ---
 
-### [1:45 – 2:45] Contact Hours, Escalation & the Immutable Audit Ledger
-> *(Start on `/simulator`. Use the **Simulated Clock** controls — RA-31.)*
+### [1:35 – 2:45] Compliance you can see, and the audit trail
+
+Screen: `/simulator`, simulated clock controls.
+
+> "The compliance story plays out over days, so I move the clock rather than fake the result.
 >
-> *"The compliance story is the part you cannot see in a five-minute demo, because it plays out
-> over days. So we move the clock instead of faking the result.*
+> *[Click 21:00 (after hours), then Run AI Recovery Agent]*
+> It is past nine at night. The RBI fair-practice contact window closes at seven. The agent
+> dispatches nothing — and every deferral is written to the audit log with the rule that fired. It
+> did not fail. It declined.
 >
-> **1. Jump to 21:00 IST** — click *21:00 (after hours)*, then *Run AI Recovery Agent*.
-> *"It is now past nine at night. The RBI Fair Practices contact window closes at 7pm, so the
-> agent dispatches nothing. Every deferral is logged with the rule that fired — it did not fail,
-> it declined."*
+> *[Click 09:00 (next morning), then Run AI Recovery Agent]*
+> Same queue, same agent, twelve hours later. Now it dispatches — WhatsApp on the first attempt, SMS
+> on the second, a voice call on the third.
 >
-> **2. Jump to 09:00 the next morning** — click *09:00 (next morning)*, then *Run AI Recovery Agent*.
-> *"Same queue, same agent, twelve hours later. Now it dispatches — WhatsApp first, then SMS on
-> the second attempt, then a voice call on the third."*
+> *[Open Customers → a customer with several attempts → Audit Timeline]*
+> This is that customer’s ledger — the agent’s arm, not the control. Every webhook, every classification, every dispatch, every
+> stopping rule, in order, with the payload behind each one. On this batch the contact-hours rule
+> fired **[read the count]** times.
 >
-> **3. Open the audit trail** — *(Click "Customers & Audit" → "Audit Timeline" on Aarav Sharma)*
-> *"Every jump I just made is in the ledger as a `clock_advanced` row — who moved time, from
-> when, to when. The clock only moves forward, so nothing can be replayed to inflate a number,
-> and the only way back to real time is reseeding, which deletes the journeys first. You are
-> looking at simulated time, and the trail says so."*
-> *"Every customer journey follows an escalation ladder:
-> 1. **Attempt 1**: WhatsApp Interactive Message with a direct Razorpay payment link.
-> 2. **Attempt 2**: Personalized SMS with regional language support.
-> 3. **Attempt 3**: AI-driven Voice Call in Hinglish.
-> 
-> Notice our **Immutable Audit Ledger**. Every webhook received, Gemini reasoning step, message dispatched, and customer reply is cryptographically hashed and permanently logged. Click any event to inspect the raw JSON payload."*
+> The clock only moves forward, and each advance is itself recorded as a `clock_advanced` row in
+> `audit_logs`, so simulated time cannot be replayed to inflate a number. You are looking at
+> simulated time, and the trail says so."
+
+**Presenter note.** The timeline you are pointing at is **arm C**, the agent's own journey. Until
+2026-09-05 this page took whichever journey the driver returned first — in practice arm A, the
+no-outreach control, the one journey guaranteed to show nothing. If you are working from an older
+build, check the arm before you record.
+
+`clock_advanced` rows are written with a null `journey_id` on purpose — a process-wide event does not
+belong in one customer's history — and are now merged into the timeline, scoped to that journey's
+lifetime and badged **System-wide · not customer-specific**. At an equal timestamp the advance is
+ordered before the dispatch it unblocked, so the row reads as cause then effect. You can point at it.
+
+### [2:45 – 3:35] Stopping rules
+
+Screen: `/simulator`, customer panel.
+
+> "Five hard stops. Watch two of them.
+>
+> *[Send 'STOP']* The customer opts out. Journey marked opted-out, DND set on the record, every
+> future attempt skipped with a logged reason.
+>
+> *[Pay with Link]* Payment lands. Journey resolved, amount recorded, outreach halts mid-sequence.
+>
+> And when the classifier meets an `error_source` it does not recognise — UPI adds `customer_psp`,
+> `network`, `beneficiary_bank` on top of the card values — it does not guess. There is no catch-all
+> default. It logs `unclassified_source` and the journey goes to the exception list. A guess produces
+> a confident wrong action; the exception list produces an honest, countable one.
+>
+> *[Customers → Exceptions tab]* **[read the count]** journeys ended here, each with the reason
+> recovery failed."
+
+**Presenter note.** Pay and STOP act on the agent's arm, never arm A — a Pay click on the control
+would contaminate it, and the route refuses (see `api/simulator/pay`). Worth ten seconds if the
+demo is running long enough to fit it; it is a detail judges notice.
 
 ---
 
-### [2:45 – 3:45] Live Interactive Sandbox & Regulatory Stopping Rules
-> *(Navigate to `/simulator`)*
-> *"Let’s test the engine in the **Interactive Simulation Sandbox**.
-> 
-> When we simulate a customer clicking **'Pay with Razorpay Link'**, the recovery engine immediately settles the amount, updates our dashboard, and moves the journey to `Resolved`.
-> 
-> Now watch what happens when a customer replies **'STOP'**. Under RBI guidelines and DPDPA, all outreach must halt immediately. RecoverAI detects the opt-out keyword, updates the customer to DND status, and aborts any future scheduled attempts.
-> 
-> Notice the top-right clock: RecoverAI strictly enforces the **8:00 AM to 7:00 PM IST contact window**, automatically deferring night-time actions."*
+### [3:35 – 4:25] The engineering
+
+Screen: terminal running `npm test`, then the validator finding.
+
+> "An external audit found 21 defects in this codebase, and my test suite passed cleanly through all
+> of them. Four were critical and reachable by an unauthenticated request. The worst: webhook
+> signature verification failed open on an unset secret. The HMAC itself was timing-safe and
+> correct — only the guard around it was wrong, which is the version that survives review, because
+> the part everyone inspects looks right.
+>
+> Then I attacked my own LLM output validator, the way someone who builds payment systems would. It
+> checked that the real payment link was present — but only matched `https?://`. So this went
+> straight through: `upi://pay?pa=fraud@okaxis&am=2499`. On Android, that opens a UPI app pre-filled
+> to pay an attacker's VPA. No phishing page, no credential capture, just money going to the wrong
+> person.
+>
+> Blocking `upi://` is a blocklist and loses to the next scheme. So I inverted it: strip the
+> known-good link out of the message, and reject if anything link-shaped is left behind. Tuned
+> deliberately broad, because the costs are not symmetric — a false positive costs one personalised
+> message, a false negative sends a customer an attacker's payment target.
+>
+> *[test run completes]* 331 tests, 47 files, three seconds. Every fix now ships with a test that
+> fails without it — which is why the UPI bypass was caught by probing rather than by hoping."
+
+**Claims that are safe to make here, and their exact scope:**
+
+| Say this | Because |
+| :--- | :--- |
+| "Timing-safe HMAC with a length guard" | `crypto.timingSafeEqual`, verified |
+| "Replay protection via a SHA-256 payload hash" | `webhook_events.payload_hash` — true of *webhooks* |
+| "Append-only audit log" | Accurate: insert-only, `audit_logs` |
+| "335 tests across 48 files" | Measured 2026-09-05 |
+| "No PII in prompts" | Data-minimisation is implemented; scope it to prompts |
+
+**Do not say the audit log is cryptographically hashed or tamper-evident.** `audit_logs` has no hash
+or chain column — id, journey, actor, event type, payload, timestamp. The SHA-256 hash is on
+`webhook_events`, for replay protection, and that is a different claim. A judge who opens
+`src/lib/db/schema.ts` will check.
 
 ---
 
-### [3:45 – 4:30] OpenSSF Security & Correctness
-> *(Show terminal running `npm test`)*
-> *"RecoverAI is built following OpenSSF Best Practices:
-> - **Timing-Safe HMAC**: Webhooks use `crypto.timingSafeEqual` to prevent side-channel timing attacks.
-> - **Zero PII Exposure**: Card numbers, phones, and bank details are stripped before LLM prompting.
-> - **Deterministic Guardrails**: 21 automated invariant tests verify stopping rules, contact hours boundaries, and idempotency."*
+### [4:25 – 4:50] Close
+
+Screen: `docs/ENGINEERING_LOG.md`, scrolling.
+
+> "All of this is in the engineering log — append-only, written as it happened, failures left in
+> after they are fixed. Including the entry where I caught myself describing unbuilt systems in the
+> past tense.
+>
+> RecoverAI turns silent revenue leaks into measured, auditable, compliant recovery. Repo and
+> architecture docs are linked. Thanks."
 
 ---
 
-### [4:30 – 5:00] Conclusion
-> *"RecoverAI bridges the gap between payment failure and revenue settlement. It protects merchant revenue, respects consumer privacy, and maintains 100% compliance with Indian financial regulations.
-> 
-> Thank you!"*
+## Recording mechanics
+
+**Capture.** QuickTime is adequate. OBS (free) adds a webcam bubble — a face in frame helps on pitch
+videos. Screen Studio (paid) auto-zooms on clicks, which matters here because the audit timeline is
+dense.
+
+**Settings.** 1920×1080. Browser zoom 110–125% — judges watch on laptops and the default renders the
+timeline unreadable. Bookmarks bar hidden, macOS Focus on, desktop cleared.
+
+**Audio beats video.** Any wired earbud mic beats the laptop built-in. Record in a soft room.
+
+**Method.** Six takes, one per section, stitched in iMovie or CapCut. A single perfect five-minute run
+is not worth chasing; energy flattens after the third attempt. Speak about 15% slower than feels
+natural — this script is dense.
+
+**Delivery.** Unlisted YouTube, not Drive — Drive permissions break and no judge will email you for
+access. Title: `RecoverAI — Razorpay AI Buildathon 2026 — Track 3`. Repo link in the description.
+
+---
+
+## Claims audit
+
+Checked against the running app on 2026-09-05. Kept here so the next revision does not quietly
+reintroduce a corrected claim.
+
+| Claim | Status |
+| :--- | :--- |
+| "21 automated invariant tests" | **Corrected** → 331 tests, 47 files |
+| "Audit events cryptographically hashed" | **Removed** — no hash column on `audit_logs`; SHA-256 hash is on `webhook_events` |
+| "`clock_advanced` rows visible on the timeline" | **Now true** — merged into the timeline and badged system-wide (was written but surfaced nowhere) |
+| "15–20% of GMV lost to declines" | **Removed** — unsourced |
+| "100% compliance with Indian financial regulations" | **Removed** — unfalsifiable; describe the specific rules enforced |
+| "Personalised Hinglish AI copy" | **Scoped** — requires `RECOVERAI_MODE=live`; mock mode uses templates |
+| "The timeline shows the agent's journey" | **Now true** — route prefers arm C (was defaulting to the arm A control) |
+| Three-arm chart, clock controls, STOP, Pay, exception list | **Verified present and working** |

--- a/docs/ENGINEERING_LOG.md
+++ b/docs/ENGINEERING_LOG.md
@@ -11,6 +11,66 @@ containing only successes is not a log.
 
 ---
 
+## 2026-09-05 — The same defect, fixed once, still live in the place that mattered most
+
+**What broke:** Rehearsing the demo video against the running app, rather than reading the script.
+Two defects, and the second one is the interesting half.
+
+**1. Every customer's audit timeline was showing the control arm.**
+
+The seeded batch gives each customer one journey per experiment arm. `GET /api/customers/[id]` took
+`journeys[0]` with no ordering, so it returned whichever row the driver produced first — in practice
+**arm A**, the no-outreach control. That is the one journey guaranteed to have no dispatch, no
+escalation and no stopping rule. So the audit timeline — the artefact Track 3 grades under "audit
+trails and explainability" — rendered as the emptiest version of itself for every customer in the
+batch. Five rows where the agent's own journey had eleven.
+
+This exact defect was found and fixed on 2026-09-01 in `api/simulator/pay`, where an unqualified
+`limit(1)` resolved arm A and put ₹6,173 into the no-agent control. That fix has a test
+(`simulator-pay-control-arm.test.ts`) and the test still passes. It was fixed *at the call site*, and
+there were two call sites.
+
+**2. `clock_advanced` was written and displayed nowhere.**
+
+Clock advances carry a null `journey_id` deliberately — moving simulated time is a process-wide act,
+and attaching it to an arbitrary customer would put a false entry in their history. But the timeline
+query filters on `journey_id = journey.id`, so every one of those rows was recorded and then visible
+in no interface at all. The audit trail could not evidence the single thing that makes contact-hours
+deferral legible instead of an unexplained gap: that time moved, when, and by how much.
+
+The demo script had a line pointing at the timeline and saying the rows were there. They were in the
+database. They were not on the screen. Nobody had checked, because the sentence is true of the system
+and false of the page, and only one of those gets read aloud.
+
+**How we got out:** The journey query orders by arm descending and prefers C. Process-wide events are
+merged into the timeline, scoped to that journey's lifetime so the page stays a record of the journey
+rather than of the whole deployment, badged `System-wide · not customer-specific`, and — at an equal
+timestamp — ordered *before* the work they unblocked, since an advance and the dispatch it enables
+share an instant and the reverse order reads as effect-then-cause.
+
+`tests/customer-audit-timeline.test.ts` covers all four properties. Reverting the route fails three
+of them, which is the bar set on 2026-08-26 and the only reason to trust the other twenty-eight.
+
+The same pass corrected three claims in `DEMO_SCRIPT.md` that had drifted from the code: the suite
+was described as "21 automated invariant tests" when it is 335 across 48 files, audit events were
+described as cryptographically hashed when `audit_logs` has no hash column (the SHA-256 hash is on
+`webhook_events`, for replay protection — a different claim), and a 15–20% GMV figure was quoted with
+no source.
+
+**What we took from this:** A fix applied at the call site does not fix the shape that caused it. The
+three-journeys-per-customer invariant is a property of the seeded data, so *every* query that reaches
+for "the journey for this customer" inherits it, and patching the one that was noticed left the
+others silently wrong. The version that hurts is not the bug you fix badly — it is the bug you fix
+well, in one place, and then stop looking for.
+
+And the second defect is the 2026-08-31 lesson arriving in a new costume. That entry closed on: a
+fallback that is too good hides the thing it is falling back from. This one is the display layer's
+version — a row that is written correctly, tested at the unit that writes it, and rendered by nothing.
+Both are only findable by running the path and looking at what a human would actually see. Neither a
+type, a linter, nor a green suite has an opinion about a record nobody displays.
+
+---
+
 ## 2026-08-31 — The AI had never run, and three separate things were hiding behind the silence
 
 **What broke:** Nothing, visibly. That was the problem.

--- a/src/app/api/customers/[id]/route.ts
+++ b/src/app/api/customers/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { customers, paymentFailures, recoveryJourneys, recoveryActions, auditLogs } from '@/lib/db/schema';
-import { eq, asc } from 'drizzle-orm';
+import { eq, asc, and, gte, isNull, desc } from 'drizzle-orm';
 
 export const dynamic = 'force-dynamic';
 
@@ -35,11 +35,19 @@ export async function GET(
       .from(paymentFailures)
       .where(eq(paymentFailures.customerId, id));
 
-    // 3. Fetch recovery journeys
+    // 3. Fetch recovery journeys.
+    //
+    // The seeded batch gives every customer one journey per experiment arm, so an unqualified
+    // `journeys[0]` picked whichever row the driver happened to return first — in practice arm A,
+    // the no-outreach control. That is the one journey guaranteed to have no dispatches, no
+    // escalation and no stopping rules, so the audit timeline for every customer rendered as the
+    // emptiest version of itself. Order by arm descending and prefer C: the agent's own arm is the
+    // one this page is about.
     const journeys = await db
       .select()
       .from(recoveryJourneys)
-      .where(eq(recoveryJourneys.customerId, id));
+      .where(eq(recoveryJourneys.customerId, id))
+      .orderBy(desc(recoveryJourneys.arm));
 
     const journey = journeys[0] || null;
 
@@ -54,24 +62,47 @@ export async function GET(
         .where(eq(recoveryActions.journeyId, journey.id))
         .orderBy(asc(recoveryActions.executedAt));
 
-      const rawLogs = await db
+      const journeyLogs = await db
         .select()
         .from(auditLogs)
         .where(eq(auditLogs.journeyId, journey.id))
         .orderBy(asc(auditLogs.createdAt));
 
-      logs = rawLogs.map((log) => {
-        let parsed = {};
-        try {
-          parsed = JSON.parse(log.eventData);
-        } catch {
-          parsed = { raw: log.eventData };
-        }
-        return {
-          ...log,
-          parsedData: parsed,
-        };
-      });
+      // Process-wide events carry a null journey id on purpose — advancing the demo clock belongs
+      // to no single customer, and attaching it to one would put a false entry in their history.
+      // The consequence was that `clock_advanced` rows were written and then visible nowhere, so
+      // the audit trail could not evidence the one thing that makes contact-hours deferral
+      // demonstrable: that time moved, when, and by how much. Merge them in, scoped to this
+      // journey's lifetime so the timeline stays a record of this journey rather than the whole
+      // deployment, and label them as system-wide in the UI.
+      const systemLogs = await db
+        .select()
+        .from(auditLogs)
+        .where(and(isNull(auditLogs.journeyId), gte(auditLogs.createdAt, journey.createdAt)))
+        .orderBy(asc(auditLogs.createdAt));
+
+      logs = [...journeyLogs, ...systemLogs]
+        .sort((a, b) => {
+          if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? -1 : 1;
+          // A clock advance and the work it unblocked share a timestamp, because the advance is
+          // what made that instant current. Order the advance first so the timeline reads as
+          // cause then effect rather than the reverse.
+          const aSystem = a.journeyId === null ? 0 : 1;
+          const bSystem = b.journeyId === null ? 0 : 1;
+          return aSystem - bSystem;
+        })
+        .map((log) => {
+          let parsed = {};
+          try {
+            parsed = JSON.parse(log.eventData);
+          } catch {
+            parsed = { raw: log.eventData };
+          }
+          return {
+            ...log,
+            parsedData: parsed,
+          };
+        });
     }
 
     return NextResponse.json({

--- a/src/components/customers/AuditTimeline.tsx
+++ b/src/components/customers/AuditTimeline.tsx
@@ -16,11 +16,13 @@ import {
   Cpu,
   User,
   Shield,
+  FastForward,
 } from 'lucide-react';
 
 export interface AuditLogEntry {
   id: string;
-  journeyId: string;
+  // Null for process-wide events — advancing the demo clock belongs to no single journey.
+  journeyId: string | null;
   actionId?: string | null;
   actor: 'system' | 'agent' | 'customer' | 'razorpay';
   eventType: string;
@@ -82,6 +84,14 @@ export function AuditTimeline({ logs, customerName = 'Customer' }: AuditTimeline
           color: 'text-sky-600 dark:text-sky-400',
           bg: 'bg-sky-50 dark:bg-sky-950/40',
           border: 'border-sky-200 dark:border-sky-800',
+        };
+      case 'clock_advanced':
+        return {
+          icon: FastForward,
+          title: 'Simulated Clock Advanced (System-Wide)',
+          color: 'text-violet-600 dark:text-violet-400',
+          bg: 'bg-violet-50 dark:bg-violet-950/40',
+          border: 'border-violet-200 dark:border-violet-800',
         };
       case 'stopping_rule_triggered':
       case 'customer_opted_out':
@@ -168,6 +178,15 @@ export function AuditTimeline({ logs, customerName = 'Customer' }: AuditTimeline
         const llmReasoning = typeof data.llmReasoning === 'string' ? data.llmReasoning : undefined;
         const rule = typeof data.rule === 'string' ? data.rule : undefined;
 
+        // A clock advance is not part of this customer's journey; it is the operator moving
+        // simulated time for the whole deployment. Say so on the row, so nobody reads it as
+        // something that happened to this customer.
+        const isSystemWide = log.journeyId === null;
+        const advancedMinutes =
+          typeof data.advancedMinutes === 'number' ? data.advancedMinutes : undefined;
+        const fromIso = typeof data.fromIso === 'string' ? data.fromIso : undefined;
+        const toIso = typeof data.toIso === 'string' ? data.toIso : undefined;
+
         return (
           <div key={log.id} className="relative group">
             {/* Timeline node icon */}
@@ -185,6 +204,14 @@ export function AuditTimeline({ logs, customerName = 'Customer' }: AuditTimeline
                     {visuals.title}
                   </span>
                   {getActorBadge(log.actor)}
+                  {isSystemWide && (
+                    <Badge
+                      variant="outline"
+                      className="bg-violet-50 text-violet-700 border-violet-200 dark:bg-violet-950/40 dark:text-violet-300 text-[10px]"
+                    >
+                      System-wide · not customer-specific
+                    </Badge>
+                  )}
                 </div>
                 <span className="text-[11px] font-mono text-zinc-500">
                   {log.createdAt}
@@ -207,6 +234,21 @@ export function AuditTimeline({ logs, customerName = 'Customer' }: AuditTimeline
                     AI Chain-of-Thought Reasoning:
                   </span>
                   {llmReasoning}
+                </div>
+              )}
+
+              {advancedMinutes !== undefined && fromIso && toIso && (
+                <div className="p-2.5 rounded-lg bg-violet-50/70 dark:bg-violet-950/30 border border-violet-100 dark:border-violet-900/40 text-xs text-violet-950 dark:text-violet-200 space-y-1">
+                  <span className="font-semibold text-violet-600 dark:text-violet-400 text-[10px] uppercase block">
+                    Simulated time moved forward by {advancedMinutes} minutes
+                  </span>
+                  <div className="font-mono text-[11px] break-all">
+                    {fromIso} → {toIso}
+                  </div>
+                  <div className="text-[11px] opacity-80">
+                    The clock only moves forward, so scheduled work is evaluated against this
+                    instant and never skipped or replayed.
+                  </div>
                 </div>
               )}
 

--- a/tests/customer-audit-timeline.test.ts
+++ b/tests/customer-audit-timeline.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import crypto from 'crypto';
+
+/**
+ * The customer audit timeline is the artefact Track 3 is graded on — "audit trails and
+ * explainability" is not something a screenshot of a dashboard can carry. Two defects made it
+ * show less than the system actually records, and both were invisible unless you compared the
+ * page against the database.
+ *
+ * 1. The seeded batch gives every customer one journey per arm. The route took `journeys[0]`
+ *    with no ordering, which in practice returned arm A — the no-outreach control, the single
+ *    journey guaranteed to have no dispatch, no escalation and no stopping rule. Every customer's
+ *    timeline therefore rendered as the emptiest version of itself.
+ *
+ * 2. `clock_advanced` rows are written with a null journey id on purpose: advancing simulated
+ *    time is a process-wide act and does not belong in one customer's history. But the timeline
+ *    query filtered on `journeyId = journey.id`, so those rows were recorded and then displayed
+ *    nowhere. The audit trail could not evidence that time moved — which is precisely what makes
+ *    contact-hours deferral legible rather than an unexplained gap.
+ */
+
+const { db } = await import('../src/lib/db');
+const { customers, paymentFailures, recoveryJourneys, auditLogs } = await import(
+  '../src/lib/db/schema'
+);
+const { GET } = await import('../src/app/api/customers/[id]/route');
+
+const SEEDED_AT = '2026-09-05T21:09:00+05:30';
+const ADVANCED_AT = '2026-09-06T09:00:00+05:30';
+const BEFORE_JOURNEY = '2026-09-01T10:00:00+05:30';
+
+let customerId: string;
+const journeyIds: Record<string, string> = {};
+
+beforeEach(async () => {
+  // Process-wide rows carry no journey id, so they are not scoped to the fixture customer and
+  // would otherwise accumulate across cases in this file's shared database.
+  await db.delete(auditLogs);
+
+  const suffix = crypto.randomUUID();
+  customerId = `cust_timeline_${suffix}`;
+
+  await db.insert(customers).values({
+    id: customerId,
+    name: 'Timeline Customer',
+    email: `timeline-${suffix}@example.com`,
+    phone: '+919876500778',
+    preferredLanguage: 'en',
+    segment: 'b2c',
+    totalFailures: 3,
+    totalRecoveredAmount: 0,
+    dndStatus: 'active',
+    createdAt: SEEDED_AT,
+    updatedAt: SEEDED_AT,
+  });
+
+  for (const arm of ['A', 'B', 'C'] as const) {
+    const failureId = `fail_tl_${arm}_${suffix}`;
+    await db.insert(paymentFailures).values({
+      id: failureId,
+      customerId,
+      razorpayPaymentId: `pay_tl_${arm}_${suffix}`,
+      razorpayOrderId: `order_tl_${arm}_${suffix}`,
+      amount: 249900,
+      currency: 'INR',
+      paymentMethod: 'card',
+      failureType: 'one_time',
+      errorCode: 'BAD_REQUEST_ERROR',
+      errorSource: 'customer',
+      errorStep: 'authorization',
+      errorReason: 'insufficient_funds',
+      errorDescription: 'Timeline fixture.',
+      arm,
+      simulationKey: `sim_tl_${suffix}`,
+      createdAt: SEEDED_AT,
+    });
+
+    journeyIds[arm] = `rj_tl_${arm}_${suffix}`;
+    await db.insert(recoveryJourneys).values({
+      id: journeyIds[arm],
+      customerId,
+      failureId,
+      status: arm === 'A' ? 'detected' : 'recovering',
+      strategy: arm === 'A' ? 'no_outreach' : 'payment_link',
+      arm,
+      amountAtRisk: 249900,
+      amountRecovered: 0,
+      maxAttempts: arm === 'A' ? 0 : 3,
+      currentAttempt: arm === 'A' ? 0 : 1,
+      currentChannel: arm === 'A' ? null : 'whatsapp',
+      createdAt: SEEDED_AT,
+      updatedAt: SEEDED_AT,
+    });
+  }
+
+  // The agent's arm dispatched; the control did not. Same instant as the clock advance, because
+  // the advance is what made that instant current.
+  await db.insert(auditLogs).values({
+    id: `audit_tl_dispatch_${suffix}`,
+    journeyId: journeyIds.C,
+    actor: 'agent',
+    eventType: 'outreach_dispatched',
+    eventData: JSON.stringify({ channel: 'whatsapp' }),
+    createdAt: ADVANCED_AT,
+  });
+
+  await db.insert(auditLogs).values({
+    id: `audit_tl_clock_${suffix}`,
+    journeyId: null,
+    actor: 'system',
+    eventType: 'clock_advanced',
+    eventData: JSON.stringify({
+      fromIso: SEEDED_AT,
+      toIso: ADVANCED_AT,
+      advancedMinutes: 711,
+      reason: 'demo_clock_advance',
+    }),
+    createdAt: ADVANCED_AT,
+  });
+
+  // A process-wide event from before this journey existed. It is not part of this journey's
+  // story and must not be merged in, or the timeline becomes a log of the whole deployment.
+  await db.insert(auditLogs).values({
+    id: `audit_tl_stale_${suffix}`,
+    journeyId: null,
+    actor: 'system',
+    eventType: 'clock_advanced',
+    eventData: JSON.stringify({ fromIso: BEFORE_JOURNEY, toIso: BEFORE_JOURNEY, advancedMinutes: 1 }),
+    createdAt: BEFORE_JOURNEY,
+  });
+});
+
+afterAll(async () => {
+  // Leave no fixture rows behind for the arm-comparison suites to trip over.
+  await db.delete(auditLogs);
+});
+
+const get = (id: string) =>
+  GET(new Request(`http://localhost/api/customers/${id}`) as never, {
+    params: Promise.resolve({ id }),
+  });
+
+const body = async (id: string) => (await get(id)).json();
+
+describe('customer audit timeline', () => {
+  it('shows the agent arm, not the no-outreach control', async () => {
+    const json = await body(customerId);
+
+    expect(json.success).toBe(true);
+    expect(json.data.journey.arm).toBe('C');
+    expect(json.data.journey.id).toBe(journeyIds.C);
+  });
+
+  it('merges process-wide clock advances into the journey timeline', async () => {
+    const json = await body(customerId);
+    const clockRows = json.data.auditLogs.filter(
+      (l: { eventType: string }) => l.eventType === 'clock_advanced'
+    );
+
+    expect(clockRows).toHaveLength(1);
+    expect(clockRows[0].journeyId).toBeNull();
+    expect(clockRows[0].parsedData.advancedMinutes).toBe(711);
+  });
+
+  it('excludes system events from before the journey began', async () => {
+    const json = await body(customerId);
+    const stale = json.data.auditLogs.filter(
+      (l: { createdAt: string }) => l.createdAt === BEFORE_JOURNEY
+    );
+
+    expect(stale).toHaveLength(0);
+  });
+
+  it('orders a clock advance before the work it unblocked at the same instant', async () => {
+    const json = await body(customerId);
+    const types = json.data.auditLogs
+      .filter((l: { createdAt: string }) => l.createdAt === ADVANCED_AT)
+      .map((l: { eventType: string }) => l.eventType);
+
+    expect(types).toEqual(['clock_advanced', 'outreach_dispatched']);
+  });
+});


### PR DESCRIPTION
Found while rehearsing the demo video against the running app rather than reading the script.

## Two defects

**1. Every customer's audit timeline showed the control arm.** `GET /api/customers/[id]` took `journeys[0]` with no ordering. The seeded batch gives each customer one journey per arm, so it returned **arm A** — the no-outreach control, the single journey guaranteed to have no dispatch, no escalation and no stopping rule. Five audit rows where the agent's journey had eleven.

This is the same defect fixed in `api/simulator/pay` on 2026-09-01. That fix was correct and its test still passes — it was applied at the call site, and there were two call sites.

**2. `clock_advanced` was written and displayed nowhere.** Those rows carry a null `journey_id` deliberately (a process-wide event does not belong in one customer's history), but the timeline filters on `journey_id`, so they rendered in no interface at all. The audit trail could not evidence that time moved — the thing that makes contact-hours deferral legible instead of an unexplained gap.

## Changes

- Order journeys by arm, prefer C
- Merge process-wide events into the timeline, scoped to the journey's lifetime, badged `System-wide · not customer-specific`
- At an equal timestamp, order the advance before the work it unblocked — cause then effect
- `tests/customer-audit-timeline.test.ts`, 4 cases; **reverting the route fails 3 of them**

## Docs

`ENGINEERING_LOG.md` entry for 2026-09-05. Three `DEMO_SCRIPT.md` claims corrected against the code: the suite is 335 tests / 48 files (not 21); `audit_logs` has no hash column, so the cryptographic-hash claim belongs to `webhook_events` and replay protection; an unsourced 15–20% GMV figure removed.

## Verification

335 tests / 48 files passing, typecheck and lint clean. Verified live: `cust_0000000000000001` now returns arm C with 11 rows, clock advances interleaved in causal order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bgj1ZdwTQ2AW3V6vgEUCKz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Customer audit timelines now consistently display the preferred recovery journey.
  - System-wide time-advance events now appear in audit timelines with clear labeling.
  - Timeline events are shown in the correct chronological order, including events occurring at the same time.

- **Documentation**
  - Updated the demo script with clearer setup, recording steps, simulator instructions, measured results, and a claims audit.
  - Corrected outdated or unsupported claims in the demo and engineering documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->